### PR TITLE
Daily sweep 2026-08-17

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Companies building foundation models (LLMs, image, audio).
 | [Mistral AI](https://mistral.ai) | 🇫🇷 France | LLMs | Open-weight models, €11.7B valuation |
 | [Aleph Alpha](https://aleph-alpha.com) | 🇩🇪 Germany | LLMs | Enterprise focus, German government contracts |
 | [Poolside](https://poolside.ai) | 🇫🇷 France | Code LLMs | Founded by ex-GitHub CTO, $500M Series B |
-| [H Company](https://hcompany.ai) | 🇫🇷 France | Agentic AI | Runner H model for autonomous tasks |
+| [H Company](https://hcompany.ai) | 🇫🇷 France | Agentic AI | Runner H agent, Holo computer-use models |
 | [Cohere](https://cohere.com) | 🇨🇦/🇬🇧 Canada/UK | LLMs | Strong European presence (London, Paris) |
 | [Kyutai](https://kyutai.org) | 🇫🇷 France | Open research | Non-profit AI lab, Moshi voice model |
 | [Silo AI](https://www.silo.ai) | 🇫🇮 Finland | LLMs | Nordic LLMs, acquired by AMD |
@@ -94,6 +94,10 @@ Companies applying AI to specific domains.
 | [Unbabel](https://unbabel.com) | 🇵🇹 Portugal | Translation | AI translation, co-creator of EuroLLM |
 | [Translated](https://translated.com) | 🇮🇹 Italy | Translation | Lara translation model, adaptive MT |
 | [Multiverse Computing](https://multiversecomputing.com) | 🇪🇸 Spain | Model compression | CompactifAI, quantum-inspired compression |
+| [Speechmatics](https://www.speechmatics.com) | 🇬🇧 UK | Speech | Speech-to-text APIs for voice AI |
+| [Tekever](https://www.tekever.com) | 🇵🇹 Portugal | Defence | Autonomous surveillance drones, intelligence as a service |
+| [Gideon Brothers](https://www.gideon.ai) | 🇭🇷 Croatia | Robotics | 3D vision autonomous mobile robots |
+| [Robovision](https://robovision.ai) | 🇧🇪 Belgium | Computer vision | No-code vision AI for industrial automation |
 
 ### AI infrastructure
 
@@ -170,6 +174,7 @@ Academic and corporate research institutions.
 | [Jülich Supercomputing Centre](https://www.fz-juelich.de/en/jsc) | 🇩🇪 Germany | Helmholtz | JUPITER, Europe's first exascale system |
 | [CINECA](https://www.cineca.it) | 🇮🇹 Italy | Consortium | Leonardo supercomputer, hosts Italian LLMs |
 | [EPFL AI Center](https://ai.epfl.ch) | 🇨🇭 Switzerland | EPFL | Co-leads the Swiss AI Initiative behind Apertus |
+| [INSAIT](https://insait.ai) | 🇧🇬 Bulgaria | Sofia University | Founded with ETH Zurich and EPFL |
 
 ---
 

--- a/data/companies.json
+++ b/data/companies.json
@@ -30,7 +30,7 @@
       "country": "France",
       "country_code": "FR",
       "focus": "Agentic AI",
-      "notes": "Runner H model for autonomous tasks"
+      "notes": "Runner H agent, Holo computer-use models"
     },
     {
       "name": "Cohere",
@@ -369,6 +369,38 @@
       "country_code": "ES",
       "focus": "Model compression",
       "notes": "CompactifAI, quantum-inspired compression"
+    },
+    {
+      "name": "Speechmatics",
+      "url": "https://www.speechmatics.com",
+      "country": "UK",
+      "country_code": "GB",
+      "focus": "Speech",
+      "notes": "Speech-to-text APIs for voice AI"
+    },
+    {
+      "name": "Tekever",
+      "url": "https://www.tekever.com",
+      "country": "Portugal",
+      "country_code": "PT",
+      "focus": "Defence",
+      "notes": "Autonomous surveillance drones, intelligence as a service"
+    },
+    {
+      "name": "Gideon Brothers",
+      "url": "https://www.gideon.ai",
+      "country": "Croatia",
+      "country_code": "HR",
+      "focus": "Robotics",
+      "notes": "3D vision autonomous mobile robots"
+    },
+    {
+      "name": "Robovision",
+      "url": "https://robovision.ai",
+      "country": "Belgium",
+      "country_code": "BE",
+      "focus": "Computer vision",
+      "notes": "No-code vision AI for industrial automation"
     }
   ],
   "infrastructure": [

--- a/data/research-labs.json
+++ b/data/research-labs.json
@@ -142,5 +142,13 @@
     "country_code": "CH",
     "affiliation": "EPFL",
     "focus": "Co-leads the Swiss AI Initiative behind Apertus"
+  },
+  {
+    "name": "INSAIT",
+    "url": "https://insait.ai",
+    "country": "Bulgaria",
+    "country_code": "BG",
+    "affiliation": "Sofia University",
+    "focus": "Founded with ETH Zurich and EPFL"
   }
 ]


### PR DESCRIPTION
Audited today's slice of 25 entries (day 229, offset 3: foundation models and the start of applied AI) and searched for gaps in under-represented countries and segments.

## Additions

Angle for this run: countries with no entry at all (Croatia, Belgium, Bulgaria) plus two missing segments (speech recognition, robotics).

- **[Speechmatics](https://www.speechmatics.com)** — 🇬🇧 UK, applied AI / speech. Registered as SPEECHMATICS LIMITED, [Companies House 07037524](https://find-and-update.company-information.service.gov.uk/company/07037524), Cambridge. Active, ~113 employees as of May 2026; lowest pooled word error rate (1.07%) of 12 services in Pipecat's August 2026 benchmark. Fills the speech-to-text gap — the list had no ASR provider.
- **[Tekever](https://www.tekever.com)** — 🇵🇹 Portugal, applied AI / defence. Lisbon, founded 2001. Became Portugal's seventh unicorn on a €70M round at a >€1B valuation ([Silicon Canals](https://siliconcanals.com/tekever-european-defence-tech-unicorn/), [Portugal Resident](https://www.portugalresident.com/drone-manufacturer-tekever-becomes-portugals-latest-unicorn/)). Second defence entry after Helsing.
- **[Gideon Brothers](https://www.gideon.ai)** — 🇭🇷 Croatia, applied AI / robotics. Zagreb, founded 2017; $31M Series A led by Koch Disruptive Technologies ([bne IntelliNews](``https://www.intellinews.com/croatia-s-gideon-brothers-raises-31mn-for-ai-and-3d-vision-based-autonomous-mobile-robots-212673/)).`` First Croatian entry and first robotics entry.
- **[Robovision](https://robovision.ai)** — 🇧🇪 Belgium, applied AI / computer vision. Ghent, founded 2009; $42M Series A led by Target Global and Astanor Ventures ([Sifted](https://sifted.eu/articles/ai-computer-vision-startup-raise-robovision-belgium-news)). First Belgian entry.
- **[INSAIT](https://insait.ai)** — 🇧🇬 Bulgaria, research labs. Founded April 2022 as a unit of Sofia University in partnership with ETH Zurich and EPFL, with an ~€85M/10-year Bulgarian government endowment ([ETH Zurich](https://ethz.ch/en/news-and-events/eth-news/news/2022/04/new-partnership-with-bulgaria-for-artificial-intelligence.html), [EU Digital Skills & Jobs](https://digital-skills-jobs.europa.eu/en/latest/news/bulgaria-become-ai-research-powerhouse-it-launches-institute-computer-science)). First Bulgarian entry.

## Corrections

- **H Company** — note changed from "Runner H model for autonomous tasks" to "Runner H agent, Holo computer-use models". The company shipped Holo 3 in 2026 and is now described as France's computer-use AI champion, having joined the NVIDIA Nemotron Coalition. Still Paris-based and active (288 employees as of June 2026).

## Removals

None.

## Verification note

Direct `curl` checks could not run this session: the sandbox egress proxy answered 403 to CONNECT for every destination host, so no URL in the slice was reachable from here (WebFetch is blocked by the same policy). Link health was instead taken from CI — the `links.yml` lychee run on main at 11:18 UTC today passed across all README links — and company status was confirmed by web search. The link check on this PR will validate the four new URLs.

## Also flagged, not changed

**DeepDNA** (🇪🇺 EU, applied AI) has no findable company register entry, VAT number or imprint; public material only claims European data centres in Germany, which CONTRIBUTING.md says is not sufficient on its own. It is already on the EU flag, which is the documented fallback. I could not reach the site to check for an imprint, so I have not proposed a removal — worth a look when the URL is reachable.
