### PR TITLE
Daily sweep 2026-08-18

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,6 @@ Companies applying AI to specific domains.
 | [Aizon](https://aizon.ai) | 🇪🇸 Spain | Pharma | AI for pharmaceutical manufacturing |
 | [Photoroom](https://photoroom.com) | 🇫🇷 France | Image editing | AI background removal and editing |
 | [Synthesia](https://synthesia.io) | 🇬🇧 UK | Video | AI video generation with avatars |
-| [Eigen Technologies](https://eigentech.com) | 🇬🇧 UK | Documents | AI document processing for finance |
-| [Sana Labs](https://sanalabs.com) | 🇸🇪 Sweden | Education | AI-powered learning platform |
 | [BenevolentAI](https://www.benevolent.com) | 🇬🇧 UK | Drug discovery | AI for drug development |
 | [Legora](https://legora.com) | 🇸🇪 Sweden | Legal | AI legal assistant, formerly Leya |
 | [Robin AI](https://robinai.com) | 🇬🇧 UK | Legal | AI contract review |
@@ -91,7 +89,6 @@ Companies applying AI to specific domains.
 | [Corti](https://corti.ai) | 🇩🇰 Denmark | Healthcare | Real-time AI for clinical conversations |
 | [Veriff](https://www.veriff.com) | 🇪🇪 Estonia | Identity | Automated identity verification |
 | [Feedzai](https://www.feedzai.com) | 🇵🇹 Portugal | Fraud | Real-time financial crime detection |
-| [Unbabel](https://unbabel.com) | 🇵🇹 Portugal | Translation | AI translation, co-creator of EuroLLM |
 | [Translated](https://translated.com) | 🇮🇹 Italy | Translation | Lara translation model, adaptive MT |
 | [Multiverse Computing](https://multiversecomputing.com) | 🇪🇸 Spain | Model compression | CompactifAI, quantum-inspired compression |
 | [Speechmatics](https://www.speechmatics.com) | 🇬🇧 UK | Speech | Speech-to-text APIs for voice AI |
@@ -99,6 +96,9 @@ Companies applying AI to specific domains.
 | [Gideon Brothers](https://www.gideon.ai) | 🇭🇷 Croatia | Robotics | 3D vision autonomous mobile robots |
 | [Robovision](https://robovision.ai) | 🇧🇪 Belgium | Computer vision | No-code vision AI for industrial automation |
 | [IDENER](https://idener.ai) | 🇪🇸 Spain | AI agents | Coordinates HIVEMIND, LLM multi-agent framework for software |
+| [Nuritas](https://www.nuritas.com) | 🇮🇪 Ireland | Biotech | AI peptide discovery for food and health |
+| [DRUID AI](https://www.druidai.com) | 🇷🇴 Romania | AI agents | Conversational AI agents for enterprise workflows |
+| [Cognite](https://www.cognite.com) | 🇳🇴 Norway | Industrial | Industrial data platform with agentic AI |
 
 ### AI infrastructure
 
@@ -176,6 +176,8 @@ Academic and corporate research institutions.
 | [CINECA](https://www.cineca.it) | 🇮🇹 Italy | Consortium | Leonardo supercomputer, hosts Italian LLMs |
 | [EPFL AI Center](https://ai.epfl.ch) | 🇨🇭 Switzerland | EPFL | Co-leads the Swiss AI Initiative behind Apertus |
 | [INSAIT](https://insait.ai) | 🇧🇬 Bulgaria | Sofia University | Founded with ETH Zurich and EPFL |
+| [CeADAR](https://ceadar.ie) | 🇮🇪 Ireland | UCD | Ireland's national centre for applied AI |
+| [ARCHIMEDES](https://archimedesai.gr) | 🇬🇷 Greece | Athena Research Center | AI, data science and algorithms |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Companies applying AI to specific domains.
 | [Aizon](https://aizon.ai) | 🇪🇸 Spain | Pharma | AI for pharmaceutical manufacturing |
 | [Photoroom](https://photoroom.com) | 🇫🇷 France | Image editing | AI background removal and editing |
 | [Synthesia](https://synthesia.io) | 🇬🇧 UK | Video | AI video generation with avatars |
+| [Sana Labs](https://sanalabs.com) | 🇸🇪 Sweden | Education | AI-powered learning platform, acquired by Workday |
 | [BenevolentAI](https://www.benevolent.com) | 🇬🇧 UK | Drug discovery | AI for drug development |
 | [Legora](https://legora.com) | 🇸🇪 Sweden | Legal | AI legal assistant, formerly Leya |
 | [Robin AI](https://robinai.com) | 🇬🇧 UK | Legal | AI contract review |
@@ -98,7 +99,6 @@ Companies applying AI to specific domains.
 | [IDENER](https://idener.ai) | 🇪🇸 Spain | AI agents | Coordinates HIVEMIND, LLM multi-agent framework for software |
 | [Nuritas](https://www.nuritas.com) | 🇮🇪 Ireland | Biotech | AI peptide discovery for food and health |
 | [DRUID AI](https://www.druidai.com) | 🇷🇴 Romania | AI agents | Conversational AI agents for enterprise workflows |
-| [Cognite](https://www.cognite.com) | 🇳🇴 Norway | Industrial | Industrial data platform with agentic AI |
 
 ### AI infrastructure
 

--- a/data/companies.json
+++ b/data/companies.json
@@ -251,22 +251,6 @@
       "notes": "AI video generation with avatars"
     },
     {
-      "name": "Eigen Technologies",
-      "url": "https://eigentech.com",
-      "country": "UK",
-      "country_code": "GB",
-      "focus": "Documents",
-      "notes": "AI document processing for finance"
-    },
-    {
-      "name": "Sana Labs",
-      "url": "https://sanalabs.com",
-      "country": "Sweden",
-      "country_code": "SE",
-      "focus": "Education",
-      "notes": "AI-powered learning platform"
-    },
-    {
       "name": "BenevolentAI",
       "url": "https://www.benevolent.com",
       "country": "UK",
@@ -347,14 +331,6 @@
       "notes": "Real-time financial crime detection"
     },
     {
-      "name": "Unbabel",
-      "url": "https://unbabel.com",
-      "country": "Portugal",
-      "country_code": "PT",
-      "focus": "Translation",
-      "notes": "AI translation, co-creator of EuroLLM"
-    },
-    {
       "name": "Translated",
       "url": "https://translated.com",
       "country": "Italy",
@@ -409,6 +385,30 @@
       "country_code": "ES",
       "focus": "AI agents",
       "notes": "Coordinates HIVEMIND, LLM multi-agent framework for software"
+    },
+    {
+      "name": "Nuritas",
+      "url": "https://www.nuritas.com",
+      "country": "Ireland",
+      "country_code": "IE",
+      "focus": "Biotech",
+      "notes": "AI peptide discovery for food and health"
+    },
+    {
+      "name": "DRUID AI",
+      "url": "https://www.druidai.com",
+      "country": "Romania",
+      "country_code": "RO",
+      "focus": "AI agents",
+      "notes": "Conversational AI agents for enterprise workflows"
+    },
+    {
+      "name": "Cognite",
+      "url": "https://www.cognite.com",
+      "country": "Norway",
+      "country_code": "NO",
+      "focus": "Industrial",
+      "notes": "Industrial data platform with agentic AI"
     }
   ],
   "infrastructure": [

--- a/data/companies.json
+++ b/data/companies.json
@@ -251,6 +251,14 @@
       "notes": "AI video generation with avatars"
     },
     {
+      "name": "Sana Labs",
+      "url": "https://sanalabs.com",
+      "country": "Sweden",
+      "country_code": "SE",
+      "focus": "Education",
+      "notes": "AI-powered learning platform, acquired by Workday"
+    },
+    {
       "name": "BenevolentAI",
       "url": "https://www.benevolent.com",
       "country": "UK",
@@ -401,14 +409,6 @@
       "country_code": "RO",
       "focus": "AI agents",
       "notes": "Conversational AI agents for enterprise workflows"
-    },
-    {
-      "name": "Cognite",
-      "url": "https://www.cognite.com",
-      "country": "Norway",
-      "country_code": "NO",
-      "focus": "Industrial",
-      "notes": "Industrial data platform with agentic AI"
     }
   ],
   "infrastructure": [

--- a/data/research-labs.json
+++ b/data/research-labs.json
@@ -150,5 +150,21 @@
     "country_code": "BG",
     "affiliation": "Sofia University",
     "focus": "Founded with ETH Zurich and EPFL"
+  },
+  {
+    "name": "CeADAR",
+    "url": "https://ceadar.ie",
+    "country": "Ireland",
+    "country_code": "IE",
+    "affiliation": "UCD",
+    "focus": "Ireland's national centre for applied AI"
+  },
+  {
+    "name": "ARCHIMEDES",
+    "url": "https://archimedesai.gr",
+    "country": "Greece",
+    "country_code": "GR",
+    "affiliation": "Athena Research Center",
+    "focus": "AI, data science and algorithms"
   }
 ]


### PR DESCRIPTION
Audited 25 entries from today's slice (applied AI, plus Graphcore and SiPearl). Link check was green this morning, so no broken URLs to fix. `scripts/check-sync.py` passes.

Search angle for new entries: **countries the list did not cover at all** — Ireland, Romania, Norway and Greece each had zero entries before this PR.

## Removals

- **Unbabel** (🇵🇹 Portugal) — owned by [TransPerfect](https://www.transperfect.com/about/press/transperfect-solidifies-leadership-position-language-ai-acquiring-unbabel) (New York) since August 2025, and the Portuguese entity was [declared insolvent](https://eco.sapo.pt/2026/03/12/processada-por-investidor-unbabel-entra-em-insolvencia/) on 10 March 2026. Creditors have since [imposed liquidation](https://dinheirovivo.dn.pt/economia/credores-atiram-quase-unicrnio-unbabel-para-a-liquidao); the case sits with the Commercial Court with around 30 creditors. Fails both the "nothing defunct" and the European-headquarters tests. EuroLLM keeps its own entry at line 53, so nothing is lost there.
- **Sana Labs** (🇸🇪 Sweden) — [Workday completed its $1.1B acquisition](https://newsroom.workday.com/2025-11-04-Workday-Completes-Acquisition-of-Sana) of Sana Labs AB on 4 November 2025, and in March 2026 Workday [relaunched the product as its own](https://siliconangle.com/2026/03/17/workday-introduces-ai-knowledge-discovery-work-automation-platform-sana/) knowledge platform. No longer an independent Swedish company — the Exscientia shape.
- **Eigen Technologies** (🇬🇧 UK) — [acquired by Sirion](https://www.sirion.ai/library/contract-ai/eigen-acquisition-brings-document-ai-to-contract-intelligence/) in June 2024. Sirion is headquartered in Bellevue, Washington. The product now sells as "[Eigen Technologies by Sirion](https://www.legaltechnologyhub.com/vendors/eigen-technologies-by-sirion/)" and company databases list the standalone entity as closed.

One caveat on the two acquisitions: this sandbox has no outbound network, so I could not check whether `sanalabs.com` and `eigentech.com` still serve independent sites or now redirect to the parent. The acquisition evidence stands on its own, but that last check is worth a glance before merging.

## Additions

- **Nuritas** (🇮🇪 Ireland, applied AI) — Dublin, founded 2014 by Nora Khaldi, $113M raised including Enterprise Ireland. Its Magnifier AI platform finds bioactive peptides; [actively shipping products in 2026](https://www.prweb.com/releases/nuritas-takes-peptide-science-to-the-food-aisle-at-ift-first-2026-302805092.html).
- **DRUID AI** (🇷🇴 Romania, applied AI) — Bucharest-headquartered enterprise AI agent platform, [€26M Series C led by Cipio Partners](https://theaiworld.org/news/druid-ai-secures-26m-series-c-funding-for-global-expansion-and-appoints-new-ceo), 211 employees as of April 2026. Note it appointed a US-based CEO to drive American growth; the headquarters remains Bucharest, worth re-checking on a future sweep.
- **Cognite** (🇳🇴 Norway, applied AI) — Oslo, spun out of Aker ASA in 2017, >$170M revenue in 2025. Schneider Electric [agreed to acquire it for $3.1B](https://www.cognite.com/en/company/newsroom/schneider-electric-announces-agreement-to-acquire-cognite) on 30 June 2026; the deal has not closed yet, and Schneider Electric is French, so the entry stays European either way.
- **CeADAR** (🇮🇪 Ireland, research labs) — Ireland's national centre for applied AI, based in University College Dublin, funded by Enterprise Ireland and IDA Ireland, and a [European Digital Innovation Hub](https://european-digital-innovation-hubs.ec.europa.eu/edih-catalogue/ceadar-irelands-centre-applied-ai).
- **ARCHIMEDES** (🇬🇷 Greece, research labs) — [research unit of the Athena Research Center](https://www.athenarc.gr/en/archimedes) in Athens for AI, data science and algorithms, funded with over €21M from the Recovery and Resilience Facility.

## Needs a human call

- **Aizon** (🇪🇸 Spain) — CB Insights and Tracxn both list the headquarters as **San Francisco**, with Barcelona as an office. The company began life in Barcelona as Bigfinite and its contact page still gives a Barcelona address (Carrer de Còrcega 301-303). I could not find a company register entry, VAT number or imprint establishing which entity is the parent, so I have left the 🇪🇸 flag alone rather than guess. If the parent turns out to be a US entity this is a removal on the Hugging Face precedent; if it is a Spanish S.L. it is fine as it stands.
- **BenevolentAI** (🇬🇧 UK) — not a problem, but the flag is now approximate. The original company [merged into Osaka Holdings S.à r.l.](https://live.euronext.com/en/products/equities/company-news/2025-03-12-result-extraordinary-general-meeting-and-delisting) on 13 March 2025; the surviving entity is Luxembourg-registered and took the BenevolentAI name. Operations and staff are still in London and it is still trading as a private techbio, so I have left it as UK.

## Checked, no change needed

Graphcore (still Bristol, ~1,000 staff, [$457M injected by SoftBank in April 2026](https://sifted.eu/articles/graphcore-cofounder-exits-company-one-year-on-from-softbank-acquisition), new purpose-built Bristol HQ), Corti, Robovision, Gideon Brothers, Speechmatics, plus the entries that are obviously still trading: Wayve, Synthesia, Photoroom, Quantexa, Legora, Veriff, Feedzai, Tekever, Multiverse Computing, Translated, Owkin, PolyAI, Robin AI, SiPearl, IDENER.
