### PR TITLE
Daily sweep 2026-08-19

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Companies building foundation models (LLMs, image, audio).
 | Company | Country | Focus | Notes |
 |---------|---------|-------|-------|
 | [Mistral AI](https://mistral.ai) | 🇫🇷 France | LLMs | Open-weight models, €11.7B valuation |
-| [Aleph Alpha](https://aleph-alpha.com) | 🇩🇪 Germany | LLMs | Enterprise focus, German government contracts |
+| [Aleph Alpha](https://aleph-alpha.com) | 🇩🇪 Germany | LLMs | German government contracts, Cohere merger pending regulatory approval |
 | [Poolside](https://poolside.ai) | 🇫🇷 France | Code LLMs | Founded by ex-GitHub CTO, $500M Series B |
 | [H Company](https://hcompany.ai) | 🇫🇷 France | Agentic AI | Runner H agent, Holo computer-use models |
 | [Cohere](https://cohere.com) | 🇨🇦/🇬🇧 Canada/UK | LLMs | Strong European presence (London, Paris) |
@@ -54,7 +54,7 @@ Companies building foundation models (LLMs, image, audio).
 | [Black Forest Labs](https://blackforestlabs.ai) | 🇩🇪 Germany | Image | FLUX models, powers Grok images |
 | [Stability AI](https://stability.ai) | 🇬🇧 UK | Image | Stable Diffusion, open source focus |
 | [NXAI](https://nx-ai.com) | 🇦🇹 Austria | xLSTM | TiRex time series model, founded by Sepp Hochreiter |
-| [Domyn](https://www.domyn.com) | 🇮🇹 Italy | LLMs | Sovereign enterprise models, formerly iGenius |
+| [Domyn](https://www.domyn.com) | 🇮🇹 Italy | LLMs | Sovereign models, leads EU EUROPA consortium, formerly iGenius |
 | [Almawave](https://www.almawave.com) | 🇮🇹 Italy | LLMs | Velvet open-weight models, trained on Leonardo |
 | [Tilde](https://tilde.ai) | 🇱🇻 Latvia | LLMs | TildeOpen, trained equally on 34 European languages |
 | [OpenEuroLLM](https://openeurollm.eu) | 🇪🇺 EU | Open models | €37.4M Digital Europe project, 20 partners |
@@ -99,6 +99,11 @@ Companies applying AI to specific domains.
 | [IDENER](https://idener.ai) | 🇪🇸 Spain | AI agents | Coordinates HIVEMIND, LLM multi-agent framework for software |
 | [Nuritas](https://www.nuritas.com) | 🇮🇪 Ireland | Biotech | AI peptide discovery for food and health |
 | [DRUID AI](https://www.druidai.com) | 🇷🇴 Romania | AI agents | Conversational AI agents for enterprise workflows |
+| [LiveEO](https://www.live-eo.com) | 🇩🇪 Germany | Earth observation | Satellite analytics for railways, grids and pipelines |
+| [OroraTech](https://ororatech.com) | 🇩🇪 Germany | Earth observation | Thermal satellite constellation for wildfire detection |
+| [constellr](https://www.constellr.com) | 🇩🇪 Germany | Earth observation | Land surface temperature from thermal infrared satellites |
+| [Kayrros](https://www.kayrros.com) | 🇫🇷 France | Climate analytics | Methane and wildfire monitoring, acquired by Energy Aspects |
+| [Whispp](https://whispp.com) | 🇳🇱 Netherlands | Speech | On-device voice reconstruction for impaired speech |
 
 ### AI infrastructure
 

--- a/data/companies.json
+++ b/data/companies.json
@@ -14,7 +14,7 @@
       "country": "Germany",
       "country_code": "DE",
       "focus": "LLMs",
-      "notes": "Enterprise focus, German government contracts"
+      "notes": "German government contracts, Cohere merger pending regulatory approval"
     },
     {
       "name": "Poolside",
@@ -110,7 +110,7 @@
       "country": "Italy",
       "country_code": "IT",
       "focus": "LLMs",
-      "notes": "Sovereign enterprise models, formerly iGenius"
+      "notes": "Sovereign models, leads EU EUROPA consortium, formerly iGenius"
     },
     {
       "name": "Almawave",
@@ -409,6 +409,46 @@
       "country_code": "RO",
       "focus": "AI agents",
       "notes": "Conversational AI agents for enterprise workflows"
+    },
+    {
+      "name": "LiveEO",
+      "url": "https://www.live-eo.com",
+      "country": "Germany",
+      "country_code": "DE",
+      "focus": "Earth observation",
+      "notes": "Satellite analytics for railways, grids and pipelines"
+    },
+    {
+      "name": "OroraTech",
+      "url": "https://ororatech.com",
+      "country": "Germany",
+      "country_code": "DE",
+      "focus": "Earth observation",
+      "notes": "Thermal satellite constellation for wildfire detection"
+    },
+    {
+      "name": "constellr",
+      "url": "https://www.constellr.com",
+      "country": "Germany",
+      "country_code": "DE",
+      "focus": "Earth observation",
+      "notes": "Land surface temperature from thermal infrared satellites"
+    },
+    {
+      "name": "Kayrros",
+      "url": "https://www.kayrros.com",
+      "country": "France",
+      "country_code": "FR",
+      "focus": "Climate analytics",
+      "notes": "Methane and wildfire monitoring, acquired by Energy Aspects"
+    },
+    {
+      "name": "Whispp",
+      "url": "https://whispp.com",
+      "country": "Netherlands",
+      "country_code": "NL",
+      "focus": "Speech",
+      "notes": "On-device voice reconstruction for impaired speech"
     }
   ],
   "infrastructure": [


### PR DESCRIPTION
## What does this PR add?

Daily sweep for 2026-08-19. Angle for new entries: **geospatial / earth observation and speech AI** — segments with almost no coverage in the list (yesterday's run used a country angle).

Audited 25 entries from `scripts/daily-slice.py` (day 231, offset 212). Today's 05:31 UTC `links.yml` run passed on `main`, so there were no broken links to repair.

### Additions

- **[LiveEO](https://www.live-eo.com)** — 🇩🇪 Germany, earth observation. Berlin-based, founded 2018. Registered as LiveEO GmbH, **HRB 200660 Charlottenburg**, Gitschiner Str. 94, 10969 Berlin; German statutory imprint names co-CEOs Daniel Seidel and Sven Przywarra. Subsidiaries in New York and Latvia, but HQ and incorporation are German. In August 2026 it won a German Space Agency grant to build a multimodal vision foundation model for earth observation.
- **[OroraTech](https://ororatech.com)** — 🇩🇪 Germany, earth observation. Munich, founded 2018 as a Technical University of Munich spin-off. Operates a thermal-infrared satellite constellation for wildfire detection; launched four SAFIRE Gen4 payloads in January 2026, and delivered Greece's dedicated wildfire constellation in 2026.
- **[constellr](https://www.constellr.com)** — 🇩🇪 Germany, earth observation. constellr GmbH, Freiburg, founded 2020. Land surface temperature from thermal infrared satellites; €37M Series A in November 2025 co-led by Alpine Space Ventures and Lakestar, and a Copernicus contract with the European Commission and ESA.
- **[Kayrros](https://www.kayrros.com)** — 🇫🇷 France, climate analytics. Paris, founded 2016. Methane and CO2 emissions tracking, wildfire and flood risk. **Acquired by Energy Aspects (London) on 21 May 2026** — noted in the entry. The acquirer is European, the Paris entity and the Kayrros brand both continue, and the domain still serves Kayrros' own press releases, so this is the Silo AI pattern rather than the Exscientia one.
- **[Whispp](https://whispp.com)** — 🇳🇱 Netherlands, speech. Leiden, founded 2019 by Joris Castermans and Akash Raj Komarlu. On-device audio-to-audio voice reconstruction for people with impaired speech; raised €5M in July 2026 and demonstrated at the Dutch Pavilion at MWC Barcelona 2026.

### Corrections

- **Aleph Alpha** — note changed from `Enterprise focus, German government contracts` to `German government contracts, Cohere merger pending regulatory approval`. Cohere announced on **24 April 2026** that it will acquire and merge with Aleph Alpha in a stock-for-stock deal valuing the combined group at ~$20B, with a $600M Series E commitment from Schwarz Group. The deal is **not closed** — it remains subject to regulatory approval and customary closing conditions. Aleph Alpha GmbH still exists in Heidelberg and the combined group is to keep dual headquarters in Canada and Germany, so the entry stays with the acquisition recorded in its note.
- **Domyn** — note changed from `Sovereign enterprise models, formerly iGenius` to `Sovereign models, leads EU EUROPA consortium, formerly iGenius`. On 19 June 2026 the European Commission named EUROPA, the consortium led by Milan-based Domyn, winner of its Frontier AI Grand Challenge, tasked with building an open-weight 400B-parameter model covering all 24 EU languages.

### Removals

None. No entry in today's slice met the evidence bar for removal.

### Needs a human call

- **Poolside** (foundation models, currently 🇫🇷 France). The evidence is genuinely contradictory and I did not touch the entry. **For Europe:** Poolside AI SAS is registered in Paris, **Siren 977666437**, and reporting as recent as May 2026 still describes it as "Paris-based"; it moved its HQ from San Francisco to Paris in 2023 after its $126M seed. **Against:** the company's own EULA at `poolside.ai/legal/eula` identifies the contracting entity as **Poolside, Inc., a Delaware corporation**, at 548 Market St, San Francisco, CA 94104, and company profiles from December 2025 onward list San Francisco as the headquarters, with Paris described as a branch hosting monthly concentrated work weeks. That is the Hugging Face pattern (Delaware parent, US HQ, European office) on one reading and the Silo AI pattern (real European operating entity) on the other. I could not fetch the site's own about/contact page from this sandbox to settle it. Someone should decide whether the French SAS is the principal entity or a subsidiary of the Delaware parent.
- **01.AI** (foundation models, 🇨🇳/🇪🇺 China/EU, note says "European operations"). I could not substantiate the European operations claim: coverage of its 2025–2026 strategy describes a B2B/2G2B focus on Chinese enterprise and government contracts with only "select high-value overseas projects", and no European entity surfaced. This is an absence of evidence, not evidence of absence, and the entry is one of the deliberate dual-flag rows, so I left it alone and am only flagging the note's wording.

## Checklist

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md)
- [x] The entry is in the correct category
- [x] The entry follows the existing table format
- [x] The link works and points to the official website
- [x] The description is concise (under 10 words)
- [x] The company/project has a clear European connection

## European connection

All five additions are incorporated and headquartered in Europe, not merely European-founded or European-staffed:

| Entry | Evidence |
|---|---|
| LiveEO | LiveEO GmbH, HRB 200660 Charlottenburg, Berlin; German imprint |
| OroraTech | German GmbH, Munich; TU Munich spin-off |
| constellr | constellr GmbH, Freiburg |
| Kayrros | French SAS, Paris; acquired by Energy Aspects, London (European parent) |
| Whispp | Dutch company, Leiden |

## Additional notes

- `python3 scripts/check-sync.py` passes: README.md and `data/` agree, Applied AI now 39 entries.
- Both README.md and `data/companies.json` were edited in the same positions; the JSON was edited surgically, not re-dumped.
- The link check on this PR will validate the five new URLs. Note that LiveEO's domain is `live-eo.com`, not `liveeo.com`.
- No open issues or open pull requests on the repo at the start of this run.
