### PR TITLE
Daily sweep 2026-08-20

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Companies building infrastructure for AI workloads.
 | [Cortecs](https://cortecs.ai) | 🇪🇺 EU | Inference | European AI gateway, LLM routing |
 | [Axelera AI](https://axelera.ai) | 🇳🇱 Netherlands | Hardware | Europa edge inference chips, €211M raised |
 | [Innatera](https://www.innatera.com) | 🇳🇱 Netherlands | Hardware | Neuromorphic microcontrollers for the sensor edge |
-| [SEMRON](https://semron.ai) | 🇩🇪 Germany | Hardware | 3D memcapacitive chips for on-device inference |
+| [SEMRON](https://semron.com) | 🇩🇪 Germany | Hardware | 3D memcapacitive chips for on-device inference |
 | [SpiNNcloud](https://spinncloud.com) | 🇩🇪 Germany | Hardware | SpiNNaker2 neuromorphic supercomputers |
 | [Fractile](https://fractile.ai) | 🇬🇧 UK | Hardware | In-memory compute for LLM inference |
 | [VSORA](https://vsora.com) | 🇫🇷 France | Hardware | Jotunn8 inference processor for data centres |

--- a/README.md
+++ b/README.md
@@ -76,7 +76,6 @@ Companies applying AI to specific domains.
 | [Sherpa.ai](https://sherpa.ai) | 🇪🇸 Spain | Assistants | Predictive AI assistant, federated learning |
 | [Clarity AI](https://clarity.ai) | 🇪🇸 Spain | Sustainability | AI for ESG and sustainability analysis |
 | [FacePhi](https://facephi.com) | 🇪🇸 Spain | Biometrics | Facial recognition for banking/KYC |
-| [Aizon](https://aizon.ai) | 🇪🇸 Spain | Pharma | AI for pharmaceutical manufacturing |
 | [Photoroom](https://photoroom.com) | 🇫🇷 France | Image editing | AI background removal and editing |
 | [Synthesia](https://synthesia.io) | 🇬🇧 UK | Video | AI video generation with avatars |
 | [Sana Labs](https://sanalabs.com) | 🇸🇪 Sweden | Education | AI-powered learning platform, acquired by Workday |
@@ -111,7 +110,7 @@ Companies building infrastructure for AI workloads.
 
 | Company | Country | Focus | Notes |
 |---------|---------|-------|-------|
-| [Graphcore](https://graphcore.ai) | 🇬🇧 UK | Hardware | IPU chips for AI workloads |
+| [Graphcore](https://graphcore.ai) | 🇬🇧 UK | Hardware | IPU chips, SoftBank subsidiary since 2024 |
 | [SiPearl](https://sipearl.com) | 🇫🇷 France | Hardware | Rhea processors for EU supercomputers |
 | [Nscale](https://nscale.com) | 🇬🇧 UK | Cloud | AI cloud platform, €163M raised |
 | [OVHcloud](https://ovhcloud.com) | 🇫🇷 France | Cloud | European cloud with AI services |
@@ -123,6 +122,11 @@ Companies building infrastructure for AI workloads.
 | [Berget AI](https://berget.ai) | 🇸🇪 Sweden | Cloud | Sovereign AI infrastructure, GDPR-compliant |
 | [Cortecs](https://cortecs.ai) | 🇪🇺 EU | Inference | European AI gateway, LLM routing |
 | [Axelera AI](https://axelera.ai) | 🇳🇱 Netherlands | Hardware | Europa edge inference chips, €211M raised |
+| [Innatera](https://www.innatera.com) | 🇳🇱 Netherlands | Hardware | Neuromorphic microcontrollers for the sensor edge |
+| [SEMRON](https://semron.ai) | 🇩🇪 Germany | Hardware | 3D memcapacitive chips for on-device inference |
+| [SpiNNcloud](https://spinncloud.com) | 🇩🇪 Germany | Hardware | SpiNNaker2 neuromorphic supercomputers |
+| [Fractile](https://fractile.ai) | 🇬🇧 UK | Hardware | In-memory compute for LLM inference |
+| [VSORA](https://vsora.com) | 🇫🇷 France | Hardware | Jotunn8 inference processor for data centres |
 | [Qdrant](https://qdrant.tech) | 🇩🇪 Germany | Vector search | Open source vector database in Rust |
 | [Weaviate](https://weaviate.io) | 🇳🇱 Netherlands | Vector search | Vector database with built-in vectorisation |
 
@@ -168,7 +172,7 @@ Academic and corporate research institutions.
 | [DFKI](https://dfki.de) | 🇩🇪 Germany | Government | German Research Center for AI |
 | [Max Planck Institute](https://is.mpg.de) | 🇩🇪 Germany | Max Planck | Intelligent Systems |
 | [ETH Zurich AI Center](https://ai.ethz.ch) | 🇨🇭 Switzerland | ETH | AI research across disciplines |
-| [CLAIRE](https://claire-ai.org) | 🇪🇺 EU | Confederation | European AI research network |
+| [CAIRNE](https://cairne.eu) | 🇪🇺 EU | Confederation | European AI research network, formerly CLAIRE |
 | [BCAM](https://bcamath.org) | 🇪🇸 Spain | Basque Government | Applied mathematics and ML |
 | [BSC-CNS](https://bsc.es) | 🇪🇸 Spain | Government | Barcelona Supercomputing Center, HPC + AI |
 | [IDSIA](https://idsia.ch) | 🇨🇭 Switzerland | USI/SUPSI | Schmidhuber's lab, LSTM origins |
@@ -270,7 +274,7 @@ Alternatives to AWS, Google Cloud, Azure.
 | [Scaleway](https://scaleway.com) | 🇫🇷 France | IaaS | Developer-friendly, open source tools |
 | [Infomaniak](https://infomaniak.com) | 🇨🇭 Switzerland | IaaS | Swiss privacy, eco-friendly |
 | [Exoscale](https://exoscale.com) | 🇨🇭 Switzerland | IaaS | Swiss cloud, simple pricing |
-| [Fuga Cloud](https://fuga.cloud) | 🇳🇱 Netherlands | IaaS | OpenStack-based |
+| [Cyso Cloud](https://cyso.cloud) | 🇳🇱 Netherlands | IaaS | OpenStack-based, formerly Fuga Cloud |
 | [UpCloud](https://upcloud.com) | 🇫🇮 Finland | IaaS | High-performance cloud |
 | [Ionos](https://ionos.com) | 🇩🇪 Germany | IaaS | Part of United Internet |
 
@@ -404,7 +408,7 @@ Places to find AI jobs in Europe.
 
 | Platform | Focus |
 |----------|-------|
-| [Otta](https://otta.com) | Curated UK/EU startup jobs |
+| [Welcome to the Jungle](https://www.welcometothejungle.com) | Curated UK/EU startup jobs, absorbed Otta |
 | [SwissDevJobs](https://swissdevjobs.ch) | Swiss tech jobs |
 | [German Tech Jobs](https://germantechjobs.de) | German tech jobs |
 | [Landing.jobs](https://landing.jobs) | European tech jobs |

--- a/data/companies.json
+++ b/data/companies.json
@@ -227,14 +227,6 @@
       "notes": "Facial recognition for banking/KYC"
     },
     {
-      "name": "Aizon",
-      "url": "https://aizon.ai",
-      "country": "Spain",
-      "country_code": "ES",
-      "focus": "Pharma",
-      "notes": "AI for pharmaceutical manufacturing"
-    },
-    {
       "name": "Photoroom",
       "url": "https://photoroom.com",
       "country": "France",
@@ -458,7 +450,7 @@
       "country": "UK",
       "country_code": "GB",
       "focus": "Hardware",
-      "notes": "IPU chips for AI workloads"
+      "notes": "IPU chips, SoftBank subsidiary since 2024"
     },
     {
       "name": "SiPearl",
@@ -547,6 +539,46 @@
       "country_code": "NL",
       "focus": "Hardware",
       "notes": "Europa edge inference chips, €211M raised"
+    },
+    {
+      "name": "Innatera",
+      "url": "https://www.innatera.com",
+      "country": "Netherlands",
+      "country_code": "NL",
+      "focus": "Hardware",
+      "notes": "Neuromorphic microcontrollers for the sensor edge"
+    },
+    {
+      "name": "SEMRON",
+      "url": "https://semron.ai",
+      "country": "Germany",
+      "country_code": "DE",
+      "focus": "Hardware",
+      "notes": "3D memcapacitive chips for on-device inference"
+    },
+    {
+      "name": "SpiNNcloud",
+      "url": "https://spinncloud.com",
+      "country": "Germany",
+      "country_code": "DE",
+      "focus": "Hardware",
+      "notes": "SpiNNaker2 neuromorphic supercomputers"
+    },
+    {
+      "name": "Fractile",
+      "url": "https://fractile.ai",
+      "country": "UK",
+      "country_code": "GB",
+      "focus": "Hardware",
+      "notes": "In-memory compute for LLM inference"
+    },
+    {
+      "name": "VSORA",
+      "url": "https://vsora.com",
+      "country": "France",
+      "country_code": "FR",
+      "focus": "Hardware",
+      "notes": "Jotunn8 inference processor for data centres"
     },
     {
       "name": "Qdrant",

--- a/data/companies.json
+++ b/data/companies.json
@@ -550,7 +550,7 @@
     },
     {
       "name": "SEMRON",
-      "url": "https://semron.ai",
+      "url": "https://semron.com",
       "country": "Germany",
       "country_code": "DE",
       "focus": "Hardware",

--- a/data/research-labs.json
+++ b/data/research-labs.json
@@ -48,12 +48,12 @@
     "focus": "AI research across disciplines"
   },
   {
-    "name": "CLAIRE",
-    "url": "https://claire-ai.org",
+    "name": "CAIRNE",
+    "url": "https://cairne.eu",
     "country": "EU",
     "country_code": "EU",
     "affiliation": "Confederation",
-    "focus": "European AI research network"
+    "focus": "European AI research network, formerly CLAIRE"
   },
   {
     "name": "BCAM",

--- a/data/resources.json
+++ b/data/resources.json
@@ -161,9 +161,9 @@
   ],
   "job_boards": [
     {
-      "name": "Otta",
-      "url": "https://otta.com",
-      "focus": "Curated UK/EU startup jobs"
+      "name": "Welcome to the Jungle",
+      "url": "https://www.welcometothejungle.com",
+      "focus": "Curated UK/EU startup jobs, absorbed Otta"
     },
     {
       "name": "SwissDevJobs",


### PR DESCRIPTION
## What does this PR add?

Daily sweep for 2026-08-20. Angle for new entries: **European AI silicon — edge inference, neuromorphic and in-memory compute hardware**. The list already carried Graphcore, SiPearl and Axelera AI, so this fills out the rest of the segment rather than reopening a country angle (18th) or a geospatial/speech angle (19th).

Audited 25 entries from `scripts/daily-slice.py` (day 232, offset 24) — the Spanish, UK, Nordic and Iberian block of Applied AI.

**Today's 05:32 UTC `links.yml` run failed on `main`** with exactly one error, `https://grommunio.com/` → **526**. See *Needs a human call* below: the company is verifiably alive and this is an origin TLS fault, so I have not touched the entry and `main` is still red.

⚠️ **[#8 (Daily sweep 2026-08-19)](https://github.com/jmbarrancoml/awesome-european-ai/pull/8) is still open and unmerged.** Nothing here overlaps with it — no shared entries, and the two branches touch different table rows. Its own proposals (LiveEO, OroraTech, constellr, Kayrros, Whispp, Aleph Alpha, Domyn, and the Poolside / 01.AI human calls) are not repeated here.

### Additions

- **[Innatera](https://www.innatera.com)** — 🇳🇱 Netherlands, hardware. **Innatera Nanosystems B.V.**, incorporated 2018 as a TU Delft spin-off, registered at Patrijsweg 20, Rijswijk (greater Delft), Zuid-Holland. Ultra-low-power neuromorphic processors for the sensor edge; launched **Pulsar**, billed as the first mass-market neuromorphic microcontroller, in May 2025, and showed production deployments at CES 2026. Series A of $21M (June 2024) on top of $6M seed, plus EIC Accelerator support. HQ is in the Netherlands with a design centre in Bangalore.
- **[SEMRON](https://semron.com)** — 🇩🇪 Germany, hardware. **SEMRON GmbH, Dresden, HRB 39815, District Court of Dresden.** Founded 2019. CapRAM™ memcapacitive devices for 3D-stacked compute-in-memory AI inference. €7.3M seed in January 2024, ~$12.3M total, plus a €2.5M EU grant (Nov 2024) for 3D-stacked inference chips running multi-billion-parameter LLMs on edge devices.
- **[SpiNNcloud](https://spinncloud.com)** — 🇩🇪 Germany, hardware. **SpiNNcloud Systems GmbH**, Dresden; a spin-off of the TU Dresden Chair of Highly-Parallel VLSI Systems and Neuro-Microelectronics, confirmed on TUDAG's own pages. Commercial SpiNNaker2 neuromorphic systems. In **April 2026** its 35,000-chip, five-million-core supercomputer went live at TU Dresden; a further deployment is going to Leipzig University. €10M funding, and part of EBRAINS 2.0.
- **[Fractile](https://fractile.ai)** — 🇬🇧 UK, hardware. Founded 2022, London, with a second site in Bristol. In-memory compute for LLM inference. **$220M Series B in May 2026** led by Accel, Founders Fund and Factorial Funds, at roughly $1B post-money; in February 2026 it committed £100M to expand its London and Bristol sites over three years, including a new hardware engineering facility in Bristol. It also has San Francisco and Taipei offices, but incorporation and HQ are British.
- **[VSORA](https://vsora.com)** — 🇫🇷 France, hardware. French semiconductor company headquartered in **Meudon-la-Forêt**. Jotunn8 AI inference processor, taped out in 2025 and entering manufacturing. Closed a round in **July 2026** led by Ardian with Otium and XAnge; earlier backers include NJJ Capital, Capgemini's ISAI Cap Venture Fund II, Omnes Capital, the EIC Fund and Germany's SPRIND.

### Corrections

- **Graphcore** — note changed from `IPU chips for AI workloads` to `IPU chips, SoftBank subsidiary since 2024`. **SoftBank Group acquired Graphcore in July 2024** for roughly $500M. This is the Silo AI pattern, not the Exscientia one: Graphcore Ltd continues to trade under its own name, HQ remains in **Bristol** with offices in Cambridge, London, Gdansk and Hsinchu, and SoftBank injected a further $457M via a share issue filed at Companies House on 10 April 2026. The entry stays; the list simply was not recording the ownership.
- **CLAIRE → CAIRNE**, URL `claire-ai.org` → `cairne.eu`. Today's link check logs the permanent redirect: `https://claire-ai.org/ --[301]--> https://cairne.eu/`. The confederation changed its acronym after a trademark challenge to the CLAIRE mark; **the legal name, Confederation of Laboratories for Artificial Intelligence Research in Europe AISBL, is unchanged**, as are its mission and its 440+ member research groups across 37 countries. Row renamed in place with `formerly CLAIRE` in the note.
- **Fuga Cloud → Cyso Cloud**, URL `fuga.cloud` → `cyso.cloud`. Today's link check logs `https://fuga.cloud/ --[301]--> https://cyso.cloud/`. **Cyso took over Fuga Cloud's activities on 1 January 2025** and fully integrated it during 2025; the service now trades as Cyso Cloud, on the same OpenStack basis, and Cyso Cloud is itself Dutch and independent, so the row keeps 🇳🇱 and stays in European alternatives.
- **Otta → Welcome to the Jungle**, URL `otta.com` → `https://www.welcometothejungle.com`. Today's link check logs `https://otta.com/ --[301]--> https://uk.welcometothejungle.com/`. Welcome to the Jungle acquired Otta in January 2024 and has since retired the brand — its own migration page is titled *"Otta is now Welcome to the Jungle"*. Because the domain now redirects to the parent and the brand is gone, the Otta row was the Exscientia case. The replacement qualifies on its own: **Welcome to the Jungle, 8-10 Rue Saint-Fiacre, 75002 Paris**, ~663 employees, $55M raised — a French company, so the job board section keeps its European coverage rather than losing a row.

### Removals

- **Aizon** (Applied AI, was 🇪🇸 Spain, *AI for pharmaceutical manufacturing*). **Removed: US incorporation and US headquarters.** The company was founded as **Bigfinite, Inc.** and Businesswire's own 5 October 2020 release is titled *"Bigfinite is Now Aizon"* — a corporate **name** change, not a redomiciliation. The surviving entity's headquarters is **44 Montgomery Street, 3rd Floor, San Francisco, CA 94104**; Barcelona is consistently described as the development office. CB Insights still files the company under `/company/bigfinite`, and a California Secretary of State business filing exists for the entity. That is the Hugging Face pattern the guidelines call out by name — Spanish founders and a real Spanish engineering office, but a US parent and a US HQ, which CONTRIBUTING.md says is not enough on its own.
  - *One caveat for the reviewer:* every source above is secondary. This sandbox has no outbound network, so I could not open `aizon.ai/contact` to read the company's own statement of its HQ. The sources agree with each other and none of them puts the headquarters in Spain, but if someone can check that page and it says Barcelona, this removal should be reverted.

### Needs a human call

- **grommunio** (European alternatives → Office and collaboration, 🇦🇹 Austria). **This is the main reason `main` is red.** Today's runs return `[526] https://grommunio.com/`. HTTP 526 is Cloudflare's *invalid SSL certificate at origin* — Cloudflare reached the server but could not validate its certificate. That is neither bot protection (which the workflow already tolerates via 403/202/429) nor a dead site. **The company is demonstrably alive:** grommunio GmbH, founded in Vienna in 2020, registered in the Austrian Firmenbuch and listed at the DC Tower, Donau-City-Straße 7, 1220 Vienna, owner-managed and independent, with an active GitHub organisation and an EU trademark (application 018443836). **I changed nothing.** The entry and its URL are both correct and I did not want to paper over a real outage by adding an exclusion — the existing exclusions (mojeek, upcloud, the socialify banner) are all for bot protection, and a permanent exclusion here would mask a genuine death later. If tomorrow's run is green, the certificate was renewed and there is nothing to do. If it stays red for several days, someone should contact grommunio or decide to exclude the host deliberately.
- **Sentence Transformers** (Open source, 🇩🇪 Germany). Today's link check logs `https://github.com/UKPLab/sentence-transformers --[301]--> https://github.com/huggingface/sentence-transformers`. The repository has moved out of the TU Darmstadt UKP Lab org and into the **Hugging Face** org. This is a genuine eligibility question rather than a fact I can settle: CONTRIBUTING.md rejects Hugging Face itself (Delaware, HQ New York), but the open source test is *"owned by a European company or run by European maintainers"*, and the SearXNG precedent says a European maintainer is sufficient — the project's lead maintainer, Tom Aarsen, is Dutch. **I left the entry alone**, including its URL, because updating the link would quietly ratify one reading of the criteria. Someone should decide whether the maintainer test still carries it, and if it does, the URL needs updating to the new org.

## Checklist

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md)
- [x] The entry is in the correct category
- [x] The entry follows the existing table format
- [x] The link works and points to the official website
- [x] The description is concise (under 10 words)
- [x] The company/project has a clear European connection

## European connection

All five additions are incorporated and headquartered in Europe, not merely European-founded or European-staffed:

| Entry | Evidence |
|---|---|
| Innatera | Innatera Nanosystems B.V., Delft/Rijswijk, Zuid-Holland; TU Delft spin-off |
| SEMRON | SEMRON GmbH, Dresden, HRB 39815 District Court of Dresden |
| SpiNNcloud | SpiNNcloud Systems GmbH, Dresden; TU Dresden spin-off via TUDAG |
| Fractile | UK company, London HQ with a Bristol engineering site |
| VSORA | French company, Meudon-la-Forêt, Île-de-France |

## Additional notes

- **CI status — red, but not from this branch.** **All ten URLs this PR adds or changes resolved successfully**, including `cairne.eu`, `cyso.cloud`, `www.welcometothejungle.com` and the five new company sites. The check is red for two unrelated reasons, both on rows this diff does not touch:
  1. `grommunio.com` → **526**, the pre-existing failure that is also red on `main`. Covered under *Needs a human call*.
  2. `vshn.ch` → **415 Unsupported Media Type**, on the VSHN row in AI infrastructure. This one looks intermittent rather than real: the identical line passed as a clean redirect (`vshn.ch --[301]--> www.vshn.ch`) in the run two minutes earlier at 06:18, and it still appears in this run's redirect list as well as its error list. I have not changed the entry. If it recurs on `main` tomorrow it is worth a proper look; a single 415 on a URL that was green minutes before is not evidence of anything.
  - The first run also showed `semron.ai --[301]--> semron.com`, so a follow-up commit switched the SEMRON entry to its canonical domain `semron.com`, which now resolves cleanly.
- `python3 scripts/check-sync.py` passes: README.md and `data/` agree. AI infrastructure 14 → 19, Applied AI 34 → 33.
- Four files touched: `README.md`, `data/companies.json`, `data/research-labs.json`, `data/resources.json`. All JSON was edited surgically — no file was re-dumped, and `data/resources.json` keeps its existing formatting.
- **Deferred to a later sweep**, to stay inside the five-correction cap. All are permanent 301s recorded in today's log, all currently harmless because lychee follows them, but each will rot eventually: `blackforestlabs.ai` → `bfl.ai`; `github.com/adap/flower` → `github.com/flwrlabs/flower`; `github.com/DS4SD/docling` → `github.com/docling-project/docling`; `worldaicannes.com` → `waicf.com`; `open-xchange.com` → `ox.io`.
- Entries checked and left alone with no change needed: **BenevolentAI** — the 2025 delisting looked like a wind-down but was not one. The original plc merged into Osaka Holdings S.à r.l. on 13 March 2025, which then converted to an S.A. and took the BenevolentAI name; the business is private, London-based, ~69 staff as of 31 May 2026, and bought a drug discovery lab at the Babraham Research Campus. **Sherpa.ai** (Bilbao, $18M July 2026), **Gideon Brothers** (Zagreb), **Robovision** (Ghent, independent) and **Feedzai** (global HQ at IPN, Rua Pedro Nunes, Coimbra — San Mateo is its separate *US* HQ) all check out. The remaining large names in the slice are obviously still trading.
- No open issues on the repo.