### PR TITLE
Daily sweep 2026-08-21

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Companies building foundation models (LLMs, image, audio).
 | [AI21 Labs](https://ai21.com) | 🇮🇱/🇪🇺 Israel/EU | LLMs | Jamba models, strong EU presence |
 | [01.AI](https://01.ai) | 🇨🇳/🇪🇺 China/EU | LLMs | Yi models, European operations |
 | [EuroLLM](https://eurollm.io/) | 🇪🇺 EU | LLMs | Multilingual model for 24 EU languages, Horizon Europe funded |
-| [Black Forest Labs](https://blackforestlabs.ai) | 🇩🇪 Germany | Image | FLUX models, powers Grok images |
+| [Black Forest Labs](https://bfl.ai) | 🇩🇪 Germany | Image | FLUX models, powers Grok images |
 | [Stability AI](https://stability.ai) | 🇬🇧 UK | Image | Stable Diffusion, open source focus |
 | [NXAI](https://nx-ai.com) | 🇦🇹 Austria | xLSTM | TiRex time series model, founded by Sepp Hochreiter |
 | [Domyn](https://www.domyn.com) | 🇮🇹 Italy | LLMs | Sovereign models, leads EU EUROPA consortium, formerly iGenius |
@@ -103,6 +103,11 @@ Companies applying AI to specific domains.
 | [constellr](https://www.constellr.com) | 🇩🇪 Germany | Earth observation | Land surface temperature from thermal infrared satellites |
 | [Kayrros](https://www.kayrros.com) | 🇫🇷 France | Climate analytics | Methane and wildfire monitoring, acquired by Energy Aspects |
 | [Whispp](https://whispp.com) | 🇳🇱 Netherlands | Speech | On-device voice reconstruction for impaired speech |
+| [Quantum Systems](https://quantum-systems.com) | 🇩🇪 Germany | Defence | VTOL reconnaissance drones, aerial intelligence software |
+| [STARK](https://stark-defence.com) | 🇩🇪 Germany | Defence | Virtus strike drones with onboard autonomy |
+| [ARX Robotics](https://www.arx-robotics.com) | 🇩🇪 Germany | Defence | Unmanned ground vehicles, Mithra retrofit OS |
+| [Comand AI](https://www.comand.ai) | 🇫🇷 France | Defence | Prevail command-and-control platform for NATO |
+| [Delian Alliance Industries](https://www.delian.ai) | 🇬🇷 Greece | Defence | Autonomous surveillance towers, border threat detection |
 
 ### AI infrastructure
 
@@ -112,12 +117,12 @@ Companies building infrastructure for AI workloads.
 |---------|---------|-------|-------|
 | [Graphcore](https://graphcore.ai) | 🇬🇧 UK | Hardware | IPU chips, SoftBank subsidiary since 2024 |
 | [SiPearl](https://sipearl.com) | 🇫🇷 France | Hardware | Rhea processors for EU supercomputers |
-| [Nscale](https://nscale.com) | 🇬🇧 UK | Cloud | AI cloud platform, €163M raised |
+| [Nscale](https://nscale.com) | 🇬🇧 UK | Cloud | AI hyperscaler, $2B Series C at $14.6B valuation |
 | [OVHcloud](https://ovhcloud.com) | 🇫🇷 France | Cloud | European cloud with AI services |
 | [Regolo](https://regolo.ai) | 🇮🇹 Italy | Inference | OpenAI-compatible API, zero data retention, 100% green energy |
 | [Scaleway](https://scaleway.com) | 🇫🇷 France | Cloud | GPU instances, European data centres |
 | [Nebius](https://nebius.com) | 🇳🇱 Netherlands | Cloud | AI-focused cloud, ex-Yandex |
-| [Northern Data](https://northerndata.de) | 🇩🇪 Germany | HPC | High-performance computing for AI |
+| [Northern Data](https://northerndata.de) | 🇩🇪 Germany | HPC | High-performance computing, RUM Group subsidiary since 2026 |
 | [VSHN](https://vshn.ch) | 🇨🇭 Switzerland | Cloud | Swiss cloud, Kubernetes for AI |
 | [Berget AI](https://berget.ai) | 🇸🇪 Sweden | Cloud | Sovereign AI infrastructure, GDPR-compliant |
 | [Cortecs](https://cortecs.ai) | 🇪🇺 EU | Inference | European AI gateway, LLM routing |
@@ -200,10 +205,10 @@ Notable open source AI projects from European developers or companies.
 | [Stable Diffusion](https://github.com/CompVis/stable-diffusion) | 🇬🇧 UK | Text-to-image model |
 | [FLUX](https://github.com/black-forest-labs/flux) | 🇩🇪 Germany | Image generation models |
 | [spaCy](https://github.com/explosion/spaCy) | 🇩🇪 Germany | NLP library |
-| [Flower](https://github.com/adap/flower) | 🇩🇪 Germany | Federated learning framework |
+| [Flower](https://github.com/flwrlabs/flower) | 🇩🇪 Germany | Federated learning framework |
 | [Haystack](https://github.com/deepset-ai/haystack) | 🇩🇪 Germany | LLM orchestration framework |
 | [Argilla](https://github.com/argilla-io/argilla) | 🇪🇸 Spain | Data labelling for LLMs |
-| [Docling](https://github.com/DS4SD/docling) | 🇨🇭 Switzerland | Document parsing |
+| [Docling](https://github.com/docling-project/docling) | 🇨🇭 Switzerland | Document parsing |
 | [Rasa Open Source](https://github.com/RasaHQ/rasa) | 🇩🇪 Germany | Conversational AI framework |
 | [OpenNMT](https://github.com/OpenNMT/OpenNMT-py) | 🇫🇷 France | Neural machine translation |
 | [Sentence Transformers](https://github.com/UKPLab/sentence-transformers) | 🇩🇪 Germany | Sentence embeddings library |

--- a/data/companies.json
+++ b/data/companies.json
@@ -82,7 +82,7 @@
     },
     {
       "name": "Black Forest Labs",
-      "url": "https://blackforestlabs.ai",
+      "url": "https://bfl.ai",
       "country": "Germany",
       "country_code": "DE",
       "focus": "Image",
@@ -441,6 +441,46 @@
       "country_code": "NL",
       "focus": "Speech",
       "notes": "On-device voice reconstruction for impaired speech"
+    },
+    {
+      "name": "Quantum Systems",
+      "url": "https://quantum-systems.com",
+      "country": "Germany",
+      "country_code": "DE",
+      "focus": "Defence",
+      "notes": "VTOL reconnaissance drones, aerial intelligence software"
+    },
+    {
+      "name": "STARK",
+      "url": "https://stark-defence.com",
+      "country": "Germany",
+      "country_code": "DE",
+      "focus": "Defence",
+      "notes": "Virtus strike drones with onboard autonomy"
+    },
+    {
+      "name": "ARX Robotics",
+      "url": "https://www.arx-robotics.com",
+      "country": "Germany",
+      "country_code": "DE",
+      "focus": "Defence",
+      "notes": "Unmanned ground vehicles, Mithra retrofit OS"
+    },
+    {
+      "name": "Comand AI",
+      "url": "https://www.comand.ai",
+      "country": "France",
+      "country_code": "FR",
+      "focus": "Defence",
+      "notes": "Prevail command-and-control platform for NATO"
+    },
+    {
+      "name": "Delian Alliance Industries",
+      "url": "https://www.delian.ai",
+      "country": "Greece",
+      "country_code": "GR",
+      "focus": "Defence",
+      "notes": "Autonomous surveillance towers, border threat detection"
     }
   ],
   "infrastructure": [
@@ -466,7 +506,7 @@
       "country": "UK",
       "country_code": "GB",
       "focus": "Cloud",
-      "notes": "AI cloud platform, €163M raised"
+      "notes": "AI hyperscaler, $2B Series C at $14.6B valuation"
     },
     {
       "name": "OVHcloud",
@@ -506,7 +546,7 @@
       "country": "Germany",
       "country_code": "DE",
       "focus": "HPC",
-      "notes": "High-performance computing for AI"
+      "notes": "High-performance computing, RUM Group subsidiary since 2026"
     },
     {
       "name": "VSHN",

--- a/data/open-source.json
+++ b/data/open-source.json
@@ -29,7 +29,7 @@
   },
   {
     "name": "Flower",
-    "url": "https://github.com/adap/flower",
+    "url": "https://github.com/flwrlabs/flower",
     "country": "Germany",
     "country_code": "DE",
     "description": "Federated learning framework"
@@ -50,7 +50,7 @@
   },
   {
     "name": "Docling",
-    "url": "https://github.com/DS4SD/docling",
+    "url": "https://github.com/docling-project/docling",
     "country": "Switzerland",
     "country_code": "CH",
     "description": "Document parsing"


### PR DESCRIPTION
## What does this PR add?

Daily sweep for 2026-08-21. Angle for new entries: **European defence and dual-use AI** — the list carried only Helsing and Tekever in a segment that took the largest European funding rounds of 2025–2026. Previous angles were countries (18th), geospatial/speech (19th) and AI silicon (20th).

Audited 25 entries from `scripts/daily-slice.py` (day 233, offset 49) — the AI infrastructure and AI tools block, plus the two most recent Applied AI additions.

**Today's 05:33 UTC `links.yml` run passed on `main`: 246 links, 0 errors.** Notably, `grommunio.com` — the 526 that made `main` red yesterday and was raised as a human call in #9 — now resolves cleanly. The origin certificate was evidently renewed, so **no action is needed there and no exclusion should be added.**

⚠️ **Two earlier sweep PRs are still open and unmerged: [#8 (2026-08-19)](https://github.com/jmbarrancoml/awesome-european-ai/pull/8) and [#9 (2026-08-20)](https://github.com/jmbarrancoml/awesome-european-ai/pull/9).** Nothing here overlaps with either — no shared entries, and the three branches touch different table rows. Their proposals (LiveEO, OroraTech, constellr, Kayrros, Whispp, Innatera, SEMRON, SpiNNcloud, Fractile, VSORA, the Aizon removal, and the Poolside / 01.AI / Sentence Transformers human calls) are not repeated. Three of the five corrections below are the stale redirects #9 explicitly deferred to a later sweep.

### Additions

- **[Quantum Systems](https://quantum-systems.com)** — 🇩🇪 Germany, defence. **Quantum-Systems GmbH, Zeppelinstr. 18, 82205 Gilching**, Bavaria; founded 2015 by Florian Seibel. Electric VTOL fixed-wing reconnaissance drones with onboard aerial-intelligence software. In February 2026 it closed a **€150M European financing package** with the EIB, Commerzbank, Deutsche Bank and KfW, announced at a press conference **at its Gilching headquarters** before the Munich Security Conference; a **$1.2B Series D in July 2026** lifted it to roughly $8B post-money. Quantum-Systems Inc. in Moorpark, California is explicitly its *North American* arm, not the parent — the Silo AI shape, not the Cognite one.
- **[STARK](https://stark-defence.com)** — 🇩🇪 Germany, defence. Founded 2024 by Florian Seibel and Johannes Schaback, led by CEO Uwe Horstmann since October 2025. Its **OWE-V Virtus** VTOL strike drone carries onboard autonomy and is already fielded in Ukraine. **€500M raised in June 2026** at a valuation above €3.5B, led by Sequoia Capital and Founders Fund with the NATO Innovation Fund, Project A and Döpfner Capital; holds a €268M German armed forces framework contract that could reach €1B.
- **[ARX Robotics](https://www.arx-robotics.com)** — 🇩🇪 Germany, defence. **ARX Landsysteme GmbH**, Munich, founded 2021. Unmanned ground vehicles plus **Mithra OS**, a retrofit AI operating system for existing military vehicles; already supplies six European armed forces. **€31M Series A** led by HV Capital with Omnes Capital, the NATO Innovation Fund and Project A, plus an **€11M extension led by Speedinvest**, taking the total to €42M.
- **[Comand AI](https://www.comand.ai)** — 🇫🇷 France, defence. Paris-based; its **Prevail** AI-native command-and-control platform has been deployed with operational units in France, Germany and Ukraine over the past twelve months. **€32M Series A in June 2026** led by Blossom Capital. Swedish defence prime **Saab took a 10% stake for €11.1M** and announced it in its own newsroom, which is about as solid as a European-backing claim gets.
- **[Delian Alliance Industries](https://www.delian.ai)** — 🇬🇷 Greece, defence. Athens, founded 2021 by former Apple roboticist Dimitrios Kottas; **formerly Lambda Automata**, which is still the slug on its Crunchbase and SEKPY (Hellenic Manufacturers of Defence Material Association) profiles. Autonomous surveillance towers and threat detection deployed on European borders. **$14M Series A in July 2025** co-led by Air Street Capital and Marathon Venture Capital, ~$20M total, and it appears as a **European Investment Fund case study**. Offices in London and Kyiv, but the company and its founding are Greek. Second Greek entry in the list after ARCHIMEDES.

### Corrections

- **Nscale** — note `AI cloud platform, €163M raised` → `AI hyperscaler, $2B Series C at $14.6B valuation`. The old figure was two rounds out of date. Nscale closed a **$2B Series C on 9 March 2026** led by Aker ASA and 8090 Industries, with Nvidia, Dell, Citadel, Jane Street, Lenovo, Nokia and Point72 participating, at a **$14.6B valuation** — billed as the largest Series C in European history. HQ remains **London**; unchanged flag.
- **Northern Data** — note `High-performance computing for AI` → `High-performance computing, RUM Group subsidiary since 2026`. **Rumble closed its acquisition on 17 June 2026** (~$767M) and now holds ~85.2% of the shares; it renamed itself **RUM Group Inc.** on 18 June and folded Northern Data's assets with Rumble Cloud into a unit called **Quake AI**. **This is the Silo AI pattern today, not the Exscientia one:** Northern Data AG still exists as a German AG at **An der Welle 3, 60322 Frankfurt am Main**, `northerndata.de` still serves its own investor-relations pages under its own brand (the Munich delisting notice is hosted there), and today's link check shows only internal redirects (`northerndata.de → /old-home → /home`), no redirect to a parent domain. The entry stays with the ownership recorded. **See the human call below — this one has a clock on it.**
- **Black Forest Labs** — URL `blackforestlabs.ai` → `bfl.ai`. Today's log: `https://blackforestlabs.ai/ --[301]--> https://bfl.ai/`. Deferred from #9.
- **Flower** — URL `github.com/adap/flower` → `github.com/flwrlabs/flower`. Today's log: `--[301]--> https://github.com/flwrlabs/flower`. The project moved from the `adap` org to `flwrlabs`. Deferred from #9.
- **Docling** — URL `github.com/DS4SD/docling` → `github.com/docling-project/docling`. Today's log: `--[301]--> https://github.com/docling-project/docling`. Moved out of IBM Research Zurich's `DS4SD` org into its own. The 🇨🇭 flag is unaffected — the project originates from IBM Research Zurich and the open source test is maintainer-based.

### Removals

None. No entry in today's slice met the evidence bar for removal — see the two human calls below for the two that came closest.

### Needs a human call

- **Rasa** (AI tools, 🇩🇪 Germany) — **contradictory, and I did not touch the entry.** *For Germany:* `rasa.com/imprint` names **Rasa Technologies GmbH, Schönhauser Allee 175, 10119 Berlin**, managing director Dr. Alan Nichol, **Amtsgericht Charlottenburg HRB 184024 B**, VAT DE311844583. That is exactly the register-plus-imprint evidence CONTRIBUTING asks for. *Against:* every commercial aggregator (PitchBook, Crunchbase, CB Insights, ZoomInfo, Craft) puts the headquarters at **4 Embarcadero Center, San Francisco**, and Rasa's own commercial terms describe the Berlin GmbH as "the Rasa Entity **for users in the European Union**" — phrasing that implies a separate US contracting entity, most likely the parent. This is the Poolside question from #8 in a different jurisdiction: a real German operating company that may be a subsidiary of a US parent. I could not open the company's about page from this sandbox to settle which entity is principal. **Note this decision also governs the separate `Rasa Open Source` row in the open source table, which is judged on maintainers rather than HQ and probably survives either way.**
- **Superwise** (AI tools, currently 🇮🇱/🇪🇺 Israel/EU) — **the 🇪🇺 half of that flag is unsubstantiated and I could not find anything behind it.** The company is **Tel Aviv**-based and was **acquired by Blattner Technologies (Nashville, Tennessee) in January 2023**; it now operates inside that US portfolio and was still active in January 2026 (a partnership with NuevoSono). I found **no European entity, office or registration** to support the EU flag. This is an absence of evidence rather than evidence of absence, so per the DeepDNA rule I left the entry alone — but unlike AI21 Labs, Superwise is **not** on the deliberate dual-flag list, so someone should decide whether it belongs in the list at all now that it is an Israeli brand under a US parent.
- **Northern Data, forward-looking** — no action today, but worth a diary note. The German AG survives, which is why the entry stays. However, its shares were **delisted from the Munich Stock Exchange's m:access on 31 July 2026** and trade in the Regulated Unofficial Market only **until 30 December 2026**, and RUM Group is actively consolidating the business under the **Quake AI** brand. If `northerndata.de` starts redirecting to a RUM Group or Quake AI domain, this becomes the Exscientia case and the entry should be removed. Worth re-checking after December.
- **Cortecs** (AI infrastructure, currently 🇪🇺 EU) — possible flag upgrade I deliberately did **not** make. Third-party European directories list its headquarters as **Austria**, which would justify 🇦🇹 over the EU fallback. But a directory listing is not a register entry, a VAT number or an imprint, and I cannot open `cortecs.ai` from this sandbox to check its own imprint. Under the rule that country claims need documentary evidence, the EU fallback is still the correct flag until someone reads that page. The company is plainly alive — 150+ EU-hosted model endpoints, 1,000+ European clients.

## Checklist

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md)
- [x] The entry is in the correct category
- [x] The entry follows the existing table format
- [x] The link works and points to the official website
- [x] The description is concise (under 10 words)
- [x] The company/project has a clear European connection

## European connection

All five additions are incorporated and headquartered in Europe, not merely European-founded or European-staffed:

| Entry | Evidence |
|---|---|
| Quantum Systems | Quantum-Systems GmbH, Zeppelinstr. 18, 82205 Gilching, Bavaria; US arm is a subsidiary |
| STARK | German company, Berlin/Munich; €268M Bundeswehr framework contract |
| ARX Robotics | ARX Landsysteme GmbH, Munich |
| Comand AI | French company, Paris; Saab holds 10% |
| Delian Alliance Industries | Greek company, Athens, formerly Lambda Automata; EIF case study, SEKPY member |

*One caveat on STARK:* sources split between **Munich** and **Berlin** for the headquarters (it has offices in both, plus Kyiv). Germany is not in doubt, so the flag is right either way, but the note deliberately avoids naming a city.

## Additional notes

- `python3 scripts/check-sync.py` passes: README.md and `data/` agree. Applied AI 34 → 39; all other section counts unchanged.
- Three files touched: `README.md`, `data/companies.json`, `data/open-source.json`. All JSON was edited surgically — no file was re-dumped, and `data/resources.json` was not touched at all.
- The link check on this PR will validate the five new URLs. Note the domains are `quantum-systems.com` (hyphenated), `stark-defence.com` (British spelling, hyphenated), `arx-robotics.com`, `comand.ai` (one "m") and `delian.ai` (not `delian.industries`).
- **Still deferred**, to stay inside the five-correction cap — all three are permanent 301s in today's log, currently harmless because lychee follows them: `open-xchange.com` → `ox.io`; `worldaicannes.com` → `waicf.com` (a two-hop redirect through `london.theaisummit.com`, the most fragile of the set); and a **newly appeared** one not previously recorded, `github.com/Giskard-AI/giskard` → `github.com/Giskard-AI/giskard-oss`, which suggests Giskard has split its open source repo from a commercial offering and may deserve a look beyond the URL.
- Entries checked and left alone with no change needed: **Nebius** (Nebius Group N.V., Schiphol Boulevard 165, Amsterdam — still Dutch, no HQ move), **Valohai** (Finland, independent, no acquisition), **Regolo** (built and run by Seeweb, Milan, Italian data centres), **Berget AI** (Stockholm; €2.1M seed February 2026 led by Luminar Ventures, launched Berget Code in May 2026 — very much alive), **Nuritas** and **DRUID AI** (added three days ago, unchanged). **Graphcore** was already handled in #9 and is not revisited here. The remaining large names in the slice — OVHcloud, Scaleway, Qdrant, Weaviate, Axelera AI, SiPearl, Jina AI, Lovable, Framer, DataSnipper, deepset, LangWatch, VSHN — are obviously still trading and were not searched individually.
- No open issues on the repo.
