### PR TITLE
Daily sweep 2026-08-22

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,11 @@ Companies applying AI to specific domains.
 | [ARX Robotics](https://www.arx-robotics.com) | 🇩🇪 Germany | Defence | Unmanned ground vehicles, Mithra retrofit OS |
 | [Comand AI](https://www.comand.ai) | 🇫🇷 France | Defence | Prevail command-and-control platform for NATO |
 | [Delian Alliance Industries](https://www.delian.ai) | 🇬🇷 Greece | Defence | Autonomous surveillance towers, border threat detection |
+| [Aignostics](https://www.aignostics.com) | 🇩🇪 Germany | Pathology | Atlas pathology foundation models, Charité spin-off |
+| [Quibim](https://quibim.com) | 🇪🇸 Spain | Medical imaging | Quantitative imaging biomarkers for precision medicine |
+| [Oxipit](https://oxipit.ai) | 🇱🇹 Lithuania | Radiology | First CE-marked autonomous chest X-ray AI |
+| [Turbine](https://turbine.ai) | 🇭🇺 Hungary | Drug discovery | Simulated cell models for virtual experiments |
+| [DoMore Diagnostics](https://www.domorediagnostics.com) | 🇳🇴 Norway | Pathology | Histotype Px predicts colorectal cancer outcomes |
 
 ### AI infrastructure
 
@@ -158,7 +163,7 @@ Companies building AI-powered developer and productivity tools.
 | [ElevenLabs](https://elevenlabs.io) | 🇵🇱/🇬🇧 Poland/UK | Voice AI | Text-to-speech, voice cloning |
 | [Onfido](https://onfido.com) | 🇬🇧 UK | Identity | AI identity verification |
 | [Mindee](https://mindee.com) | 🇫🇷 France | Documents | AI document parsing API |
-| [Rossum](https://rossum.ai) | 🇨🇿 Czechia | Documents | AI document processing |
+| [Rossum](https://rossum.ai) | 🇨🇿 Czechia | Documents | AI document processing, acquired by Coupa |
 | [n8n](https://n8n.io) | 🇩🇪 Germany | Automation | Fair-code workflow and agent builder |
 | [Giskard](https://www.giskard.ai) | 🇫🇷 France | Testing | LLM evaluation and red teaming |
 | [Langfuse](https://langfuse.com) | 🇩🇪 Germany | LLM observability | Open source tracing, owned by ClickHouse |

--- a/data/companies.json
+++ b/data/companies.json
@@ -481,6 +481,46 @@
       "country_code": "GR",
       "focus": "Defence",
       "notes": "Autonomous surveillance towers, border threat detection"
+    },
+    {
+      "name": "Aignostics",
+      "url": "https://www.aignostics.com",
+      "country": "Germany",
+      "country_code": "DE",
+      "focus": "Pathology",
+      "notes": "Atlas pathology foundation models, Charité spin-off"
+    },
+    {
+      "name": "Quibim",
+      "url": "https://quibim.com",
+      "country": "Spain",
+      "country_code": "ES",
+      "focus": "Medical imaging",
+      "notes": "Quantitative imaging biomarkers for precision medicine"
+    },
+    {
+      "name": "Oxipit",
+      "url": "https://oxipit.ai",
+      "country": "Lithuania",
+      "country_code": "LT",
+      "focus": "Radiology",
+      "notes": "First CE-marked autonomous chest X-ray AI"
+    },
+    {
+      "name": "Turbine",
+      "url": "https://turbine.ai",
+      "country": "Hungary",
+      "country_code": "HU",
+      "focus": "Drug discovery",
+      "notes": "Simulated cell models for virtual experiments"
+    },
+    {
+      "name": "DoMore Diagnostics",
+      "url": "https://www.domorediagnostics.com",
+      "country": "Norway",
+      "country_code": "NO",
+      "focus": "Pathology",
+      "notes": "Histotype Px predicts colorectal cancer outcomes"
     }
   ],
   "infrastructure": [
@@ -780,7 +820,7 @@
       "country": "Czechia",
       "country_code": "CZ",
       "focus": "Documents",
-      "notes": "AI document processing"
+      "notes": "AI document processing, acquired by Coupa"
     },
     {
       "name": "n8n",


### PR DESCRIPTION
Audited 25 entries from today's slice (12 AI tools, 13 research labs). The 05:00 UTC link check on `main` passed clean, so there are no broken links to fix. `scripts/check-sync.py` passes before and after.

Search angle for new entries: **European medical AI — imaging, pathology and clinical decision support**, a segment the list did not cover at all beyond drug discovery, weighted towards countries with no entries.

## Additions

- **[Aignostics](https://www.aignostics.com)** 🇩🇪 — Aignostics GmbH, Berlin, a 2018 spin-off from Charité – Universitätsmedizin Berlin. Announced Atlas 2 in January 2026: ~2B parameters, trained on 5M+ slide images, top average score across 80 public pathology benchmarks. $53.9M raised, including a $34M Series B in October 2024. Berlin HQ with a New York office.
- **[Quibim](https://quibim.com)** 🇪🇸 — Quibim S.L., Valencia, founded 2015. Closed a $50M Series A on 28 January 2025 led by Asabys and Buenavista. Valencia is the stated HQ, with further offices in Madrid, Barcelona, Cambridge and New York. Used by 170+ healthcare institutions.
- **[Oxipit](https://oxipit.ai)** 🇱🇹 — Vilnius. ChestLink is the first CE Class IIb certified *autonomous* chest X-ray AI, meaning it reports high-confidence normal studies without a radiologist. Acquired by **Sectra AB (Linköping, Sweden) in March 2026** — a European-to-European deal; oxipit.ai still serves an Oxipit-branded site with its own newsroom, and the portfolio expanded into chest CT and MSK X-ray in 2026. **First Lithuanian entry.**
- **[Turbine](https://turbine.ai)** 🇭🇺 — Budapest. Simulated Cell platform for in-silico experiments, used across 30+ discovery programmes with MSD, AstraZeneca and Bayer. Raised a $25M Series B on 24 February 2026 led by Interactive Venture Partners; ~85 staff. **First Hungarian entry.**
- **[DoMore Diagnostics](https://www.domorediagnostics.com)** 🇳🇴 — Oslo, founded 2020 out of the Oslo University Hospital DoMore! project. CE-marked Histotype Px Colorectal stratifies patients into risk groups to guide adjuvant chemotherapy; underlying data published in The Lancet and The Lancet Oncology. Awarded a NOK 16M Research Council of Norway grant, with new clinical data presented at ASCO GI 2026. **First Norwegian entry.**

## Corrections

- **Rossum** — acquired by **Coupa** (San Mateo) on 13 May 2026, announced at Coupa Inspire 2026, ending its standalone vendor status. Coupa is keeping the Rossum brand and the Czech entity stands, so this is the Silo AI shape rather than the Exscientia one: the entry stays with the acquisition recorded in its note.

## Removals

None this run.

## Needs a human call

- **Onfido** 🇬🇧 — genuinely ambiguous, so I have left the entry untouched. Both signals are strong and they point opposite ways:
  - *Points to removal:* Entrust (Minneapolis) completed the acquisition on 9 April 2024, and Entrust now publishes a page titled ["Onfido Is Now Entrust IDV"](https://www.entrust.com/company/onfido-is-now-entrust). The developer docs at `documentation.onfido.com` now render as Entrust documentation, the SDKs are being replaced by Entrust-branded ones during 2026, and Entrust's terms-of-service link carries an `edc_redirect=Onfido-Redirect` parameter.
  - *Points to keeping:* **Onfido Ltd, Companies House 07479524, is still active**, registered at 9 Devonshire Square, London, with accounts made up to 31 March 2025 and the next set due by 31 December 2026. The European entity has not gone away the way Exscientia's did.

  The deciding test in CONTRIBUTING terms is whether `onfido.com` itself now redirects to `entrust.com`. **I cannot check that** — this sweep runs in a sandbox with no outbound network, and the CI link check follows redirects silently, so its pass tells us nothing either way. One look at `onfido.com` in a browser settles it: if it lands on Entrust, this is Exscientia and the entry should go; if it still serves an Onfido-branded site, it is Silo AI and the note should read "acquired by Entrust".

## Notes on the open sweep PRs

#8, #9 and #10 are all still open, and all three are **behind `main`** — several of their additions (Speechmatics, Tekever, Gideon Brothers, Robovision, IDENER, Nuritas, DRUID AI, INSAIT, CeADAR, ARCHIMEDES) have since landed on `main` directly, so those branches re-propose entries that already exist and will conflict. What is still genuinely pending in them:

- **#8** — LiveEO, OroraTech, constellr, Kayrros, Whispp
- **#9** — Innatera, SEMRON, SpiNNcloud, Fractile, VSORA; the CLAIRE → CAIRNE rename; Fuga Cloud → Cyso Cloud; Otta → Welcome to the Jungle; the Aizon removal
- **#10** — Quantum Systems, STARK, ARX Robotics, Comand AI, Delian Alliance Industries

Today's run deliberately avoided all of those names and their segments (earth observation, speech, AI silicon, defence). CLAIRE came up in today's audit slice and is left alone because #9 already proposes the rename. These three probably want rebasing or closing before they drift further.
