### PR TITLE
Daily sweep 2026-08-23

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Companies building infrastructure for AI workloads.
 | [VSORA](https://vsora.com) | 🇫🇷 France | Hardware | Jotunn8 inference processor for data centres |
 | [Qdrant](https://qdrant.tech) | 🇩🇪 Germany | Vector search | Open source vector database in Rust |
 | [Weaviate](https://weaviate.io) | 🇳🇱 Netherlands | Vector search | Vector database with built-in vectorisation |
+| [Verda](https://verda.com) | 🇫🇮 Finland | Cloud | GPU cloud with own datacentres, formerly DataCrunch |
 
 ### AI tools
 
@@ -167,6 +168,7 @@ Companies building AI-powered developer and productivity tools.
 | [n8n](https://n8n.io) | 🇩🇪 Germany | Automation | Fair-code workflow and agent builder |
 | [Giskard](https://www.giskard.ai) | 🇫🇷 France | Testing | LLM evaluation and red teaming |
 | [Langfuse](https://langfuse.com) | 🇩🇪 Germany | LLM observability | Open source tracing, owned by ClickHouse |
+| [LatticeFlow AI](https://latticeflow.ai) | 🇨🇭 Switzerland | AI governance | EU AI Act evaluation, creators of COMPL-AI |
 
 ---
 
@@ -207,17 +209,17 @@ Notable open source AI projects from European developers or companies.
 | Project | Origin | Description |
 |---------|--------|-------------|
 | [Mistral models](https://github.com/mistralai) | 🇫🇷 France | Open-weight LLMs |
-| [Stable Diffusion](https://github.com/CompVis/stable-diffusion) | 🇬🇧 UK | Text-to-image model |
+| [Stable Diffusion](https://github.com/CompVis/stable-diffusion) | 🇩🇪/🇬🇧 Germany/UK | Text-to-image model from CompVis LMU Munich |
 | [FLUX](https://github.com/black-forest-labs/flux) | 🇩🇪 Germany | Image generation models |
 | [spaCy](https://github.com/explosion/spaCy) | 🇩🇪 Germany | NLP library |
 | [Flower](https://github.com/flwrlabs/flower) | 🇩🇪 Germany | Federated learning framework |
 | [Haystack](https://github.com/deepset-ai/haystack) | 🇩🇪 Germany | LLM orchestration framework |
-| [Argilla](https://github.com/argilla-io/argilla) | 🇪🇸 Spain | Data labelling for LLMs |
+| [Argilla](https://github.com/argilla-io/argilla) | 🇪🇸 Spain | Data labelling for LLMs, part of Hugging Face |
 | [Docling](https://github.com/docling-project/docling) | 🇨🇭 Switzerland | Document parsing |
-| [Rasa Open Source](https://github.com/RasaHQ/rasa) | 🇩🇪 Germany | Conversational AI framework |
-| [OpenNMT](https://github.com/OpenNMT/OpenNMT-py) | 🇫🇷 France | Neural machine translation |
+| [Rasa Open Source](https://github.com/RasaHQ/rasa) | 🇩🇪 Germany | Conversational AI framework, now in maintenance mode |
+| [OpenNMT](https://github.com/OpenNMT/OpenNMT-py) | 🇫🇷 France | Neural machine translation, succeeded by Eole |
 | [Sentence Transformers](https://github.com/UKPLab/sentence-transformers) | 🇩🇪 Germany | Sentence embeddings library |
-| [Flair](https://github.com/flairNLP/flair) | 🇩🇪 Germany | NLP framework by Zalando |
+| [Flair](https://github.com/flairNLP/flair) | 🇩🇪 Germany | NLP framework from Humboldt University Berlin |
 | [PySyft](https://github.com/OpenMined/PySyft) | 🇬🇧 UK | Privacy-preserving ML |
 | [scikit-learn](https://github.com/scikit-learn/scikit-learn) | 🇫🇷 France | Machine learning library from Inria |
 | [llama.cpp](https://github.com/ggml-org/llama.cpp) | 🇧🇬 Bulgaria | LLM inference in C/C++, by Georgi Gerganov |
@@ -233,6 +235,9 @@ Notable open source AI projects from European developers or companies.
 | [Teuken-7B](https://opengpt-x.de) | 🇩🇪 Germany | OpenGPT-X model for the 24 EU languages |
 | [Salamandra](https://huggingface.co/BSC-LT) | 🇪🇸 Spain | Multilingual open models from Barcelona |
 | [Velvet](https://huggingface.co/Almawave) | 🇮🇹 Italy | Italian open-weight models by Almawave |
+| [Meilisearch](https://github.com/meilisearch/meilisearch) | 🇫🇷 France | Search engine in Rust with hybrid vector search |
+| [ZenML](https://github.com/zenml-io/zenml) | 🇩🇪 Germany | MLOps framework for reproducible ML pipelines |
+| [Rerun](https://github.com/rerun-io/rerun) | 🇸🇪 Sweden | Visualisation and data stack for robotics |
 
 ---
 

--- a/data/companies.json
+++ b/data/companies.json
@@ -675,6 +675,14 @@
       "country_code": "NL",
       "focus": "Vector search",
       "notes": "Vector database with built-in vectorisation"
+    },
+    {
+      "name": "Verda",
+      "url": "https://verda.com",
+      "country": "Finland",
+      "country_code": "FI",
+      "focus": "Cloud",
+      "notes": "GPU cloud with own datacentres, formerly DataCrunch"
     }
   ],
   "tools": [
@@ -845,6 +853,14 @@
       "country_code": "DE",
       "focus": "LLM observability",
       "notes": "Open source tracing, owned by ClickHouse"
+    },
+    {
+      "name": "LatticeFlow AI",
+      "url": "https://latticeflow.ai",
+      "country": "Switzerland",
+      "country_code": "CH",
+      "focus": "AI governance",
+      "notes": "EU AI Act evaluation, creators of COMPL-AI"
     }
   ]
 }

--- a/data/open-source.json
+++ b/data/open-source.json
@@ -9,9 +9,9 @@
   {
     "name": "Stable Diffusion",
     "url": "https://github.com/CompVis/stable-diffusion",
-    "country": "UK",
-    "country_code": "GB",
-    "description": "Text-to-image model"
+    "country": "Germany/UK",
+    "country_code": "DE/GB",
+    "description": "Text-to-image model from CompVis LMU Munich"
   },
   {
     "name": "FLUX",
@@ -46,7 +46,7 @@
     "url": "https://github.com/argilla-io/argilla",
     "country": "Spain",
     "country_code": "ES",
-    "description": "Data labelling for LLMs"
+    "description": "Data labelling for LLMs, part of Hugging Face"
   },
   {
     "name": "Docling",
@@ -60,14 +60,14 @@
     "url": "https://github.com/RasaHQ/rasa",
     "country": "Germany",
     "country_code": "DE",
-    "description": "Conversational AI framework"
+    "description": "Conversational AI framework, now in maintenance mode"
   },
   {
     "name": "OpenNMT",
     "url": "https://github.com/OpenNMT/OpenNMT-py",
     "country": "France",
     "country_code": "FR",
-    "description": "Neural machine translation"
+    "description": "Neural machine translation, succeeded by Eole"
   },
   {
     "name": "Sentence Transformers",
@@ -81,7 +81,7 @@
     "url": "https://github.com/flairNLP/flair",
     "country": "Germany",
     "country_code": "DE",
-    "description": "NLP framework by Zalando"
+    "description": "NLP framework from Humboldt University Berlin"
   },
   {
     "name": "PySyft",
@@ -187,5 +187,26 @@
     "country": "Italy",
     "country_code": "IT",
     "description": "Italian open-weight models by Almawave"
+  },
+  {
+    "name": "Meilisearch",
+    "url": "https://github.com/meilisearch/meilisearch",
+    "country": "France",
+    "country_code": "FR",
+    "description": "Search engine in Rust with hybrid vector search"
+  },
+  {
+    "name": "ZenML",
+    "url": "https://github.com/zenml-io/zenml",
+    "country": "Germany",
+    "country_code": "DE",
+    "description": "MLOps framework for reproducible ML pipelines"
+  },
+  {
+    "name": "Rerun",
+    "url": "https://github.com/rerun-io/rerun",
+    "country": "Sweden",
+    "country_code": "SE",
+    "description": "Visualisation and data stack for robotics"
   }
 ]


### PR DESCRIPTION
Today's slice was the research labs and the open source projects (25 entries). The 05:00 UTC link check on `main` passed, so there are no broken URLs to fix. `scripts/check-sync.py` passes on this branch.

Search angle for new entries: **European open source AI tooling and MLOps infrastructure**.

## Additions

- **[Meilisearch](https://github.com/meilisearch/meilisearch)** 🇫🇷 — open source search engine in Rust, now with hybrid vector search. Meili SAS, headquartered at 52 boulevard de Sébastopol, Paris; founded 2018 by Quentin de Quelen, Clément Renault and Thomas Payet. ([company profile](https://www.crunchbase.com/organization/meilisearch))
- **[ZenML](https://github.com/zenml-io/zenml)** 🇩🇪 — open source MLOps framework for reproducible pipelines. ZenML GmbH, Schellingstraße, Munich, founded July 2021 by Adam Probst and Hamza Tahir. ([company page](https://www.zenml.io/company), [Startup-Atlas entry](https://www.startup-atlas.de/company/zenml))
- **[Rerun](https://github.com/rerun-io/rerun)** 🇸🇪 — open source visualisation and data stack for robotics and spatial AI. Stockholm, founded 2022; $17M seed led by Point Nine in March 2025. ([TechCrunch](https://techcrunch.com/2025/03/20/reruns-open-source-ai-platform-for-robots-drones-and-cars-revs-up-with-17m-seed/), [media kit](https://rerun.io/media))
- **[LatticeFlow AI](https://latticeflow.ai)** 🇨🇭 — AI governance and evaluation, added under AI tools. LatticeFlow AG, Zurich, ETH Zurich spin-off founded 2020; creators of COMPL-AI, the first EU AI Act evaluation framework for generative models, built with ETH Zurich and INSAIT. ([about page](https://latticeflow.ai/company/about), [Venturelab profile](https://www.venturelab.swiss/latticeflow))
- **[Verda](https://verda.com)** 🇫🇮 — GPU cloud running its own datacentres, added under AI infrastructure. Lapinlahdenkatu 16, Helsinki; renamed from DataCrunch in November 2025; raised €100M in April 2026 led by Lifeline Ventures with Tesi and Varma. ([company page](https://verda.com/company), [EU-Startups](``https://www.eu-startups.com/2026/04/helsinki-based-ai-infrastructure-company-verda-raises-e100-million-plans-to-hire-100-people-by-year-end/``)) First Finnish entry in the infrastructure table.

## Corrections

- **Stable Diffusion** — the row pointed at `CompVis/stable-diffusion` but carried a UK flag alone. CompVis is the Computer Vision and Learning group at LMU Munich, which owns the repository and developed the underlying latent diffusion model; Stability AI (already listed separately as a UK company) funded the compute and the release. Now dual-flagged 🇩🇪/🇬🇧, following the Jitsi precedent. ([CompVis org](https://github.com/orgs/CompVis/repositories), [Stable Diffusion](https://en.wikipedia.org/wiki/Stable_Diffusion))
- **Flair** — described as "NLP framework by Zalando". It was released by Zalando Research in 2018, but development moved with Alan Akbik to Humboldt University Berlin, which now hosts and leads it. ([HU Berlin Flair page](https://www.informatik.hu-berlin.de/en/forschung-en/gebiete/ml-en/Flair/Flair), [Akbik's project page](https://alanakbik.github.io/research/flair))
- **Rasa Open Source** — in maintenance mode since 2025; active development moved to Rasa Pro and the CALM engine. Still Apache-2.0 and still German, so the entry stays with the status noted. ([Rasa release and maintenance policy](https://rasa.com/rasa-product-release-and-maintenance-policy))
- **OpenNMT** — `OpenNMT-py` was put into maintenance mode in July 2024, with `eole-nlp/eole` named by the maintainers as its successor. ([forum announcement](https://forum.opennmt.net/t/opennmt-py-is-now-in-maintenance-mode-use-eole-instead/5792))
- **Argilla** — acquired by Hugging Face in June 2024 for a reported $10M. The repository is still active and the team is still in Madrid, so this is the Sana Labs shape: the entry stays with the acquisition in its description. ([Argilla announcement](https://argilla.io/blog/argilla-joins-hugggingface/), [Across Legal, which advised on the sale](https://acrosslegal.com/en/argilla/))

## Removals

None this run.

## Needs a human call

- **PySyft** 🇬🇧 — the maintainers pass the CONTRIBUTING test (Andrew Trask and the core team work from Oxford, and the project is actively developed, with releases through 2026). But openmined.org describes OpenMined as a 501(c)(3), which is a US tax status, and I could not find a UK company or charity register entry behind it. I looked at openmined.org, the GitHub organisation and the PySyft release history. The flag may be right on maintainers and wrong on the entity; leaving it alone. ([OpenMined PySyft page](https://openmined.org/pysyft/))

## Rejected while searching

- **Neptune** (neptune.ai, Warsaw) — would have been a first Polish tooling entry, but OpenAI agreed to acquire it in December 2025 and the headquarters moved to Palo Alto. Fails the headquarters criterion for the same reason as Cognite. ([acquisition notice](https://neptune.ai/about-us))
- **Vespa.ai** — engineering hub and CEO are in Trondheim and there is a Norwegian entity (org. 985535558), but I could not establish whether the post-Yahoo-spinout parent is Norwegian or US, so I did not propose it.
- **Bielik**, **Langfuse**, **Giskard** — already in the list.

## Note on the other open sweep pull requests

#8, #9, #10 and #11 are still open and unmerged. This branch is cut from `main` and does not touch anything they propose.
