### PR TITLE
Daily sweep 2026-08-24

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ Companies applying AI to specific domains.
 | [BenevolentAI](https://www.benevolent.com) | 🇬🇧 UK | Drug discovery | AI for drug development |
 | [Legora](https://legora.com) | 🇸🇪 Sweden | Legal | AI legal assistant, formerly Leya |
 | [Robin AI](https://robinai.com) | 🇬🇧 UK | Legal | AI contract review |
+| [Noxtua](https://noxtua.com) | 🇩🇪 Germany | Legal | Sovereign legal AI for German and EU law |
+| [Jimini AI](https://www.jimini.ai) | 🇫🇷 France | Legal | AI copilot for law firms |
+| [Luminance](https://www.luminance.com) | 🇬🇧 UK | Legal | Contract analysis and legal diligence |
 | [Wayve](https://wayve.ai) | 🇬🇧 UK | Autonomous driving | End-to-end driving models, no HD maps |
 | [Quantexa](https://www.quantexa.com) | 🇬🇧 UK | Decision intelligence | Entity resolution for banks and government |
 | [PolyAI](https://poly.ai) | 🇬🇧 UK | Voice agents | Customer service assistants over the phone |

--- a/data/companies.json
+++ b/data/companies.json
@@ -275,6 +275,30 @@
       "notes": "AI contract review"
     },
     {
+      "name": "Noxtua",
+      "url": "https://noxtua.com",
+      "country": "Germany",
+      "country_code": "DE",
+      "focus": "Legal",
+      "notes": "Sovereign legal AI for German and EU law"
+    },
+    {
+      "name": "Jimini AI",
+      "url": "https://www.jimini.ai",
+      "country": "France",
+      "country_code": "FR",
+      "focus": "Legal",
+      "notes": "AI copilot for law firms"
+    },
+    {
+      "name": "Luminance",
+      "url": "https://www.luminance.com",
+      "country": "UK",
+      "country_code": "GB",
+      "focus": "Legal",
+      "notes": "Contract analysis and legal diligence"
+    },
+    {
       "name": "Wayve",
       "url": "https://wayve.ai",
       "country": "UK",


### PR DESCRIPTION
Automated daily sweep. Angle for new entries: **European legal AI**.

Today's slice (open-source LLM projects, EU funding programmes, international conferences) was audited and needed no corrections — see below. `scripts/check-sync.py` passes; main's scheduled link check was green this morning.

## Additions

- **Noxtua** — 🇩🇪 Berlin. Sovereign legal AI for German and EU law. Register: Noxtua AG, Amtsgericht Charlottenburg HRB 202784 B (rebranding from Xayn AG to Noxtua SE). €80.7M Series B led by C.H. Beck. Not yet in the list; existing legal entries are Legora (SE) and Robin AI (UK).
- **Jimini AI** — 🇫🇷 Paris. AI copilot for law firms (research, analysis, drafting). Registered at 4 rue Jules Lefebvre, 75009 Paris; founded 2023; partnership with the Paris Bar. €6.8M raised.
- **Luminance** — 🇬🇧 Cambridge. Contract analysis and legal diligence. Founded 2015 out of University of Cambridge; independent, $75M Series C (Point72, March Capital); ~100+ staff at 20 Station Road, Cambridge.

New URLs are validated by the link check on this PR.

## Corrections / Removals

None. Today's audited slice was verified unchanged:
- Almawave/Velvet (🇮🇹, publicly traded, Apache-2 open-weight models) — active.
- Giskard (🇫🇷 Paris) — independent, no acquisition; still open-source ML/LLM testing.
- Tilde / TildeOpen (🇱🇻 Latvia) — active, shipped a new MT platform in Feb 2026.
- Apertus (🇨🇭 ETH/EPFL/CSCS) — active open model.
- EU funding programmes (Horizon Europe, EIC, EuroHPC, ERC, etc.) and international conferences (NeurIPS, ICML, ICLR) — stable institutions, no change.

## Needs a human call

Nothing this run.

## Note on open PRs

Sweep PRs #8, #9, #10, #11 and #12 are still open and unmerged. This PR does not duplicate their proposals (silicon, defence, medical, open-source tooling, geospatial/speech). Notably #9's proposed removal of **Aizon** (San Francisco HQ) has not merged, so Aizon still appears in `README.md` and is untouched here.
