### PR TITLE
Daily sweep 2026-08-25

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ Major AI events in Europe.
 | [ICML](https://icml.cc) | Rotating | July | ML research |
 | [ICLR](https://iclr.cc) | Rotating | May | ML research |
 | [AI Summit London](https://london.theaisummit.com) | 🇬🇧 London | June | Enterprise AI |
-| [World AI Cannes Festival](https://www.worldaicannes.com) | 🇫🇷 Cannes | February | AI ecosystem |
+| [World AI Cannes Festival](https://waicf.com) | 🇫🇷 Cannes | February | AI ecosystem |
 | [Applied Machine Learning Days](https://appliedmldays.org) | 🇨🇭 Lausanne | February | Research meets industry, hosted at EPFL |
 | [RAISE Summit](https://www.raisesummit.com) | 🇫🇷 Paris | July | Agentic and sovereign AI |
 | [World Summit AI](https://worldsummit.ai) | 🇳🇱 Amsterdam | October | Enterprise AI, ethics and policy |
@@ -446,6 +446,10 @@ Online communities focused on European AI.
 | [ML in PL](https://mlinpl.org) | Website | Polish machine learning community and conference |
 | [PyData Amsterdam](https://amsterdam.pydata.org) | Meetup | Dutch data science and ML community |
 | [appliedAI](https://www.appliedai.de) | Website | German applied AI initiative and network |
+| [EurAI](https://www.eurai.org) | Website | Umbrella of European national AI societies |
+| [ADRA](https://adr-association.eu) | Website | European AI, data and robotics partnership |
+| [AI Sweden](https://www.ai.se/en) | Website | Swedish national centre for applied AI |
+| [Data Science Society](https://www.datasciencesociety.net) | Website | Bulgarian data science community and datathons |
 
 ---
 
@@ -458,6 +462,7 @@ European-originated courses and materials.
 | [Elements of AI](https://www.elementsofai.com) | 🇫🇮 Finland | Free intro course in 26 languages |
 | [scikit-learn MOOC](https://inria.github.io/scikit-learn-mooc/) | 🇫🇷 France | Free machine learning course from Inria |
 | [UvA Deep Learning Tutorials](https://uvadlc-notebooks.readthedocs.io) | 🇳🇱 Netherlands | Course notebooks from Amsterdam |
+| [Una Europa AI in Society](https://www.una-europa.eu/study/mooc-ai-society) | 🇧🇪 Belgium | Free course from eleven European universities |
 
 ---
 

--- a/data/resources.json
+++ b/data/resources.json
@@ -118,7 +118,7 @@
     },
     {
       "name": "World AI Cannes Festival",
-      "url": "https://www.worldaicannes.com",
+      "url": "https://waicf.com",
       "location": "Cannes, France",
       "when": "February",
       "focus": "AI ecosystem"
@@ -221,6 +221,30 @@
       "url": "https://www.appliedai.de",
       "platform": "Website",
       "focus": "German applied AI initiative and network"
+    },
+    {
+      "name": "EurAI",
+      "url": "https://www.eurai.org",
+      "platform": "Website",
+      "focus": "Umbrella of European national AI societies"
+    },
+    {
+      "name": "ADRA",
+      "url": "https://adr-association.eu",
+      "platform": "Website",
+      "focus": "European AI, data and robotics partnership"
+    },
+    {
+      "name": "AI Sweden",
+      "url": "https://www.ai.se/en",
+      "platform": "Website",
+      "focus": "Swedish national centre for applied AI"
+    },
+    {
+      "name": "Data Science Society",
+      "url": "https://www.datasciencesociety.net",
+      "platform": "Website",
+      "focus": "Bulgarian data science community and datathons"
     }
   ],
   "learning": [
@@ -244,6 +268,13 @@
       "country": "Netherlands",
       "country_code": "NL",
       "type": "Course notebooks from Amsterdam"
+    },
+    {
+      "name": "Una Europa AI in Society",
+      "url": "https://www.una-europa.eu/study/mooc-ai-society",
+      "country": "Belgium",
+      "country_code": "BE",
+      "type": "Free course from eleven European universities"
     }
   ]
 }


### PR DESCRIPTION
Automated daily sweep. Angle for new entries: **European AI communities and learning resources** — the two thinnest tables in the list (5 and 3 entries), and exactly the block today's slice covers. Previous angles were countries, geospatial/speech, silicon, defence, medical, open-source tooling and legal.

Audited 25 entries from `scripts/daily-slice.py` (day 237, offset 149) — events, job boards, communities, learning resources and the European alternatives IaaS rows.

**Today's 05:32 UTC `links.yml` run on `main` passed** (run [#100](https://github.com/jmbarrancoml/awesome-european-ai/actions/runs/32813253159)), so there are no broken links to repair. `scripts/check-sync.py` passes before and after.

## Additions

Four communities and one learning resource:

- **[EurAI](https://www.eurai.org)** — the European Association for Artificial Intelligence, formed in 1982 as ECCAI. It is the umbrella body for the national AI societies, with 25+ active members holding independent legal status (AFIA, AIxIA, AEPIA, BNVKI, GI-FBKI, APPIA, ARIA, BAIA, EETN, NJSZT, SAIS, SGAICO and others). Its own charter puts the **registered office in Brussels, AI Laboratory, Pleinlaan 2, Building K2** (VUB), transferable only within Belgium by board decision published in the *Annexes du Moniteur Belge*. ([charter](https://www.eurai.org/eurai-charter-translation), [member list](https://www.eurai.org/members))
- **[ADRA](https://adr-association.eu)** — the AI, Data and Robotics Association, an international non-profit **incorporated in Brussels as an asbl** on 21 May 2021 by five European organisations: BDVA, CLAIRE, ELLIS, EurAI and euRobotics. It is the private side of the Horizon Europe European Partnership on AI, Data and Robotics, having signed its MoU with the Commission on 23 June 2021, and now has 180+ member organisations. ([about page](https://adr-association.eu/about-us))
- **[AI Sweden](https://www.ai.se/en)** — Sweden's national centre for applied AI, funded by the Swedish government and its partners, with 130+ partners across the public sector, private sector and academia and a core team of 100+. Headquartered at **Lindholmen Science Park, Gothenburg**, with nodes in Lund, Linköping, Stockholm and Luleå. Opening the AI Gothenburg founder hub in 2026. This is the direct analogue of the **appliedAI** row already in the table. ([about page](https://www.ai.se/en/about), [OECD.AI policy entry](https://oecd.ai/en/dashboards/policy-initiatives/ai-sweden-5011))
- **[Data Science Society](https://www.datasciencesociety.net)** — volunteer data science community **headquartered in Oborishte, Sofia**, running online datathons, monthly challenges, meetups and summer schools, with 4,500+ registered members across 50+ countries. It ran the first practical data challenge in Central and Eastern Europe (Datathon Bulgaria 2017). **Still active:** datathon cases posted as recently as 10 February 2026, and a 13 May 2026 event in Sofia with the AI Engineer Foundation Bulgaria. ([events](https://www.datasciencesociety.net/events/))
- **[Una Europa AI in Society](https://www.una-europa.eu/study/mooc-ai-society)** — free MOOC on AI and its societal impact, co-developed by universities within the Una Europa alliance (Edinburgh, Helsinki, Complutense Madrid, Paris 1 Panthéon-Sorbonne and others), with the materials designed by content experts at the University of Helsinki. No prior AI knowledge required; optional modules on top of a compulsory core. Added under learning resources. ([course page](https://www.una-europa.eu/study/mooc-ai-society), [EU Digital Skills catalogue entry](https://digital-skills-jobs.europa.eu/en/learning-space/training-catalogue/ai-society))

  *On the flag:* 🇧🇪 rather than 🇪🇺, because there is a real entity behind it and CONTRIBUTING reserves the EU flag for when there is not. **Una Europa vzw** is a non-profit association under Belgian law, established 1 February 2019, based at KU Leuven Campus Brussels, Warmoesberg 26, 1000 Brussels, and it appears on the EU transparency register via [lobbyfacts](https://www.lobbyfacts.eu/datacard/una-europa-vzw?rid=755664138709-48&sid=141355). The eleven-university character is in the description instead. Happy to switch to 🇪🇺 if you read the alliance as the principal rather than the vzw.

New URLs are validated by the link check on this PR.

## Corrections

- **World AI Cannes Festival** — URL `https://www.worldaicannes.com` → `https://waicf.com`. This is the two-hop redirect through `london.theaisummit.com` that was recorded but **deliberately deferred in both #9 and #10** to stay inside their correction caps; it is in today's slice, so it is taken here. `waicf.com` is the festival's own current site. The event itself is healthy — 12–13 February 2026 at the Palais des Festivals, 10,000+ visitors, 320 speakers, 220 exhibitors, run by the EuropIA Institute with the City of Cannes. ([Palais des Festivals listing](https://en.palaisdesfestivals.com/offers/world-artificial-intelligence-cannes-festival-waicf-cannes-en-3686586/), [EuropIA](https://instituteuropia.eu/waicf-2k26))

## Removals

None. Nothing in today's slice came close to the evidence bar.

## Needs a human call

Nothing this run.

## Audited and left alone

Verified still active and correct, no change needed:

- **Events** — Applied Machine Learning Days (10–13 Feb 2026, SwissTech Convention Center, EPFL's 10th anniversary edition), RAISE Summit (8–9 July 2026, Carrousel du Louvre, Paris), ai-PULSE (4th edition, 13 October 2026, Station F, still run by Scaleway), World Summit AI and ECML PKDD (stable institutions).
- **Job boards** — SwissDevJobs (80,000+ monthly users, site updated 17 July 2026), German Tech Jobs, EU Data Jobs (owned by R&C Technologies, founded by Regina Carvalho), EURAXESS.
- **Communities** — LAION (German non-profit, Hamburg; Re-LAION-5B, LeoLM, Open Empathic), AI Atlas (open-source European AI directory by northwindlabs), ML in PL, PyData Amsterdam (10–12 September 2026, NDSM Loods), appliedAI (appliedAI Initiative GmbH, August-Everding-Straße 25, Munich, **HRB 255519 District Court of Munich**, 120+ staff, UnternehmerTUM joint venture).
- **Learning** — Elements of AI, scikit-learn MOOC, UvA Deep Learning Tutorials.
- **European alternatives (IaaS)** — Hetzner, OVHcloud, Scaleway, Infomaniak, Exoscale. All obviously still trading; not searched individually.

One thing worth recording without proposing a change: **Landing.jobs** was **acquired by Damia Group Portugal in April 2025** and now sits alongside that group's recruitment and RPO services. This is European-to-European, the brand and the `landing.jobs` domain are both intact, and it published a Tech Talent Trends 2026 report — so the entry is fine as it stands. The job boards table carries no acquisition notes and has only a short focus column, so I have not tried to squeeze it in; flagging it in case you want the note.

## Note on the open sweep pull requests

⚠️ **Six sweep PRs are now open and unmerged: #8, #9, #10, #11, #12 and #13.** This branch is cut from current `main` and does not duplicate anything they propose.

Two points of contact with them, both handled:

- **Otta** is in today's slice. **#9 already proposes replacing it with Welcome to the Jungle** (`otta.com` now 301s to the parent — the Exscientia case). I have deliberately left the row untouched rather than re-propose it.
- The **WAICF redirect** is the opposite case: #9 and #10 both recorded it and both explicitly deferred it to a later sweep, so it was still unclaimed. It is the one correction here.

The older branches are drifting further behind `main` with each run — #11 already documented that several of #8/#9/#10's additions have since landed on `main` directly and will conflict. They probably want reviewing, rebasing or closing.

## Checklist

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md)
- [x] The entry is in the correct category
- [x] The entry follows the existing table format
- [x] The link works and points to the official website
- [x] The description is concise (under 10 words)
- [x] The company/project has a clear European connection

## Additional notes

- `python3 scripts/check-sync.py` passes: README.md and `data/` agree. Communities 5 → 9, Learning resources 3 → 4; all other section counts unchanged.
- Two files touched: `README.md` and `data/resources.json`. The JSON was edited surgically — the file was not re-dumped and keeps its existing formatting (38 insertions, 2 deletions across both files).
- No open issues on the repo.
