### PR TITLE
Add LLM Tech to AI infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Companies building infrastructure for AI workloads.
 | [Nscale](https://nscale.com) | 🇬🇧 UK | Cloud | AI hyperscaler, $2B Series C at $14.6B valuation |
 | [OVHcloud](https://ovhcloud.com) | 🇫🇷 France | Cloud | European cloud with AI services |
 | [Regolo](https://regolo.ai) | 🇮🇹 Italy | Inference | OpenAI-compatible API, zero data retention, 100% green energy |
-| [LLM Tech](https://llmtech.eu) | 🇵🇱 Poland | Inference | Qwen3.8-27B API on EU hardware, zero data retention, live measured status page |
+| [LLM Tech](https://llmtech.eu) | 🇪🇺 EU | Inference | Qwen3.8-27B API on EU hardware, zero data retention |
 | [Scaleway](https://scaleway.com) | 🇫🇷 France | Cloud | GPU instances, European data centres |
 | [Nebius](https://nebius.com) | 🇳🇱 Netherlands | Cloud | AI-focused cloud, ex-Yandex |
 | [Northern Data](https://northerndata.de) | 🇩🇪 Germany | HPC | High-performance computing, RUM Group subsidiary since 2026 |

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Companies building infrastructure for AI workloads.
 | [Nscale](https://nscale.com) | 🇬🇧 UK | Cloud | AI cloud platform, €163M raised |
 | [OVHcloud](https://ovhcloud.com) | 🇫🇷 France | Cloud | European cloud with AI services |
 | [Regolo](https://regolo.ai) | 🇮🇹 Italy | Inference | OpenAI-compatible API, zero data retention, 100% green energy |
+| [LLM Tech](https://llmtech.eu) | 🇵🇱 Poland | Inference | Qwen3.8-27B API on EU hardware, zero data retention, live measured status page |
 | [Scaleway](https://scaleway.com) | 🇫🇷 France | Cloud | GPU instances, European data centres |
 | [Nebius](https://nebius.com) | 🇳🇱 Netherlands | Cloud | AI-focused cloud, ex-Yandex |
 | [Northern Data](https://northerndata.de) | 🇩🇪 Germany | HPC | High-performance computing for AI |

--- a/data/companies.json
+++ b/data/companies.json
@@ -717,6 +717,14 @@
       "notes": "OpenAI-compatible API, zero data retention, 100% green energy"
     },
     {
+      "name": "LLM Tech",
+      "url": "https://llmtech.eu",
+      "country": "EU",
+      "country_code": "EU",
+      "focus": "Inference",
+      "notes": "Qwen3.8-27B API on EU hardware, zero data retention"
+    },
+    {
       "name": "Scaleway",
       "url": "https://scaleway.com",
       "country": "France",


### PR DESCRIPTION
Adds LLM Tech (llmtech.eu) to the AI infrastructure table — Polish inference provider serving Qwen3.8-27B from EU hardware (German edge, Finnish GPU datacenter), zero data retention, public live status page with measured numbers (llmtech.eu/status).

Disclosure: I run LLM Tech.