### PR TITLE
Daily sweep 2026-08-26

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,10 @@ Companies applying AI to specific domains.
 | [Oxipit](https://oxipit.ai) | 🇱🇹 Lithuania | Radiology | First CE-marked autonomous chest X-ray AI |
 | [Turbine](https://turbine.ai) | 🇭🇺 Hungary | Drug discovery | Simulated cell models for virtual experiments |
 | [DoMore Diagnostics](https://www.domorediagnostics.com) | 🇳🇴 Norway | Pathology | Histotype Px predicts colorectal cancer outcomes |
+| [CuspAI](https://cusp.ai) | 🇬🇧 UK | Materials | Search engine for new materials, Cambridge |
+| [Jua](https://jua.ai) | 🇨🇭 Switzerland | Weather | EPT-2 physics model for energy forecasting |
+| [TWAICE](https://www.twaice.com) | 🇩🇪 Germany | Batteries | Predictive analytics for grid storage and EVs |
+| [Ecorobotix](https://ecorobotix.com) | 🇨🇭 Switzerland | Agriculture | Vision-guided ultra-high precision spraying |
 
 ### AI infrastructure
 
@@ -304,9 +308,9 @@ Alternatives to Google Workspace, Microsoft 365.
 |---------|---------|------|-------|
 | [Nextcloud](https://nextcloud.com) | 🇩🇪 Germany | Open source | File sync, calendar, office suite |
 | [ONLYOFFICE](https://onlyoffice.com) | 🇱🇻 Latvia | Open source | Full office suite, MS Office compatible |
-| [Collabora Online](https://collaboraoffice.com) | 🇬🇧 UK | Open source | LibreOffice-based, self-hosted |
+| [Collabora Online](https://collaboraonline.com) | 🇬🇧 UK | Open source | LibreOffice-based, self-hosted |
 | [CryptPad](https://cryptpad.org) | 🇫🇷 France | Open source | End-to-end encrypted collaboration |
-| [Open-Xchange](https://open-xchange.com) | 🇩🇪 Germany | Open source | Email, calendar, groupware |
+| [Open-Xchange](https://ox.io) | 🇩🇪 Germany | Open source | Email, calendar, groupware |
 | [Grommunio](https://grommunio.com) | 🇦🇹 Austria | Open source | Exchange/Outlook replacement |
 
 ### Communication
@@ -317,7 +321,7 @@ Alternatives to Slack, Microsoft Teams, Zoom.
 |---------|---------|------|-------|
 | [Element](https://element.io) | 🇬🇧 UK | Open source | Matrix protocol, used by NATO/governments |
 | [Wire](https://wire.com) | 🇨🇭 Switzerland | Freemium | E2E encrypted, enterprise focus |
-| [Threema Work](https://threema.ch) | 🇨🇭 Switzerland | Paid | Anonymous messaging, no phone required |
+| [Threema Work](https://threema.com) | 🇨🇭 Switzerland | Paid | Anonymous messaging, no phone required |
 | [Rocket.Chat](https://rocket.chat) | 🇧🇷/🇪🇺 Brazil/EU | Open source | Self-hosted Slack alternative |
 | [Mattermost](https://mattermost.com) | 🇺🇸/🇪🇺 US/EU | Open source | Self-hosted, EU data centers |
 | [Nextcloud Talk](https://nextcloud.com) | 🇩🇪 Germany | Open source | Video calls, integrated with Nextcloud |
@@ -344,7 +348,7 @@ Alternatives to Gmail, Outlook.
 | [Mailbox.org](https://mailbox.org) | 🇩🇪 Germany | Paid | Privacy-focused, office suite included |
 | [Posteo](https://posteo.de) | 🇩🇪 Germany | Paid | Green hosting, anonymous signup |
 | [Fastmail](https://fastmail.com) | 🇦🇺/🇪🇺 Australia/EU | Paid | EU data center option |
-| [Soverin](https://soverin.net) | 🇳🇱 Netherlands | Paid | Privacy-first email |
+| [Soverin](https://soverin.com) | 🇳🇱 Netherlands | Paid | Privacy-first email, acquired by The Sharing Group |
 
 ### Analytics
 

--- a/data/companies.json
+++ b/data/companies.json
@@ -545,6 +545,38 @@
       "country_code": "NO",
       "focus": "Pathology",
       "notes": "Histotype Px predicts colorectal cancer outcomes"
+    },
+    {
+      "name": "CuspAI",
+      "url": "https://cusp.ai",
+      "country": "UK",
+      "country_code": "GB",
+      "focus": "Materials",
+      "notes": "Search engine for new materials, Cambridge"
+    },
+    {
+      "name": "Jua",
+      "url": "https://jua.ai",
+      "country": "Switzerland",
+      "country_code": "CH",
+      "focus": "Weather",
+      "notes": "EPT-2 physics model for energy forecasting"
+    },
+    {
+      "name": "TWAICE",
+      "url": "https://www.twaice.com",
+      "country": "Germany",
+      "country_code": "DE",
+      "focus": "Batteries",
+      "notes": "Predictive analytics for grid storage and EVs"
+    },
+    {
+      "name": "Ecorobotix",
+      "url": "https://ecorobotix.com",
+      "country": "Switzerland",
+      "country_code": "CH",
+      "focus": "Agriculture",
+      "notes": "Vision-guided ultra-high precision spraying"
     }
   ],
   "infrastructure": [


### PR DESCRIPTION
Slice audited: the whole **European alternatives** section (25 entries, day 238, offset 174). Search angle for new entries: **European AI for climate, energy, materials and agriculture** — a segment the list had no entries for.

## Additions

- **[CuspAI](https://cusp.ai)** — 🇬🇧 UK, Applied AI / Materials. CUSP AI LIMITED, [Companies House 15549537](https://find-and-update.company-information.service.gov.uk/company/15549537), registered office 20 Station Road, Cambridge CB1 2JD, incorporated 9 March 2024. Founded by Chad Edwards and Max Welling; generative AI plus physics-based simulation for materials discovery. [€85M+ Series A in September 2025](``https://www.eu-startups.com/2025/09/british-startup-cuspai-secures-e85-million-to-transform-materials-discovery-with-ai),`` then [€393.2M at a €2.2B valuation in July 2026](``https://www.eu-startups.com/2026/07/cuspai-raises-e393-2-million-at-e2-2-billion-valuation-launches-ai-materials-foundry-to-accelerate-materials-discovery/).`` Cambridge is the headquarters; Amsterdam is the second site.
- **[Jua](https://jua.ai)** — 🇨🇭 Switzerland, Applied AI / Weather. Zurich-based, founded 2022, ~$30M raised. Builds EPT-2, a spatiotemporal transformer foundation model trained on 5+ PB of weather and climate data, sold into energy trading. Confirmed Zurich HQ via the [Nebius customer story](https://nebius.com/customer-stories/jua).
- **[TWAICE](https://www.twaice.com)** — 🇩🇪 Germany, Applied AI / Batteries. Munich, founded 2018 by Stephan Rohr and Michael Baumann. Predictive battery analytics for grid storage and EVs. [€24M EIB venture debt loan under InvestEU, February 2026](``https://www.eu-startups.com/2026/02/munich-based-twaice-secures-e24-million-eib-loan-to-scale-predictive-battery-analytics-for-europes-energy-transition/).``
- **[Ecorobotix](https://ecorobotix.com)** — 🇨🇭 Switzerland, Applied AI / Agriculture. Ecorobotix SA, Rue Galilée 6, Yverdon-les-Bains, [CHE-284.375.582](https://www.northdata.com/Ecorobotix%20SA,%20Yverdon-les-Bains/CHE-284.375.582), commercial register entry last modified 13 January 2026, status active. ARA ultra-high precision sprayer uses camera-based crop/weed recognition at 6×6 cm resolution, cutting inputs by up to 95%.

## Corrections

All four are canonical-domain moves surfaced by the redirect list in today's link check.

- **Collabora Online**: `collaboraoffice.com` → **`collaboraonline.com`**. The old domain redirects through `collaboraoffice.com` → `www.collaboraonline.com`; the [product site](https://www.collaboraonline.com/) and [about page](https://www.collaboraonline.com/about-us/) both live on the new one. UK entity unchanged.
- **Open-Xchange**: `open-xchange.com` → **`ox.io`**. 301 to `ox.io`; the [company page](https://ox.io/about-ox/company/) confirms OX Software GmbH is unchanged, only the domain is shorter.
- **Threema Work**: `threema.ch` → **`threema.com`**. 301 chain `threema.ch` → `threema.com` → `threema.com/en`, part of the 2025 rebrand. Still Threema GmbH, Switzerland.
- **Soverin**: `soverin.net` → **`soverin.com`**, and the note now records the acquisition. Soverin B.V. is still Amsterdam-based and still trading under its own brand on its own domain — the Silo AI shape, not the Exscientia one — but it was [acquired by The Sharing Group in September 2025](https://ioplus.nl/en/posts/soverin-email-provider-acquired-by-the-sharing-group), which the entry did not say.

## Removals

None. Nothing in today's slice turned up an insolvency, a shutdown, a redirect into a parent brand, or a move out of Europe.

## Not duplicated here

**Fuga Cloud → Cyso Cloud** is already proposed in [#9](https://github.com/jmbarrancoml/awesome-european-ai/pull/9) and was left alone in this branch, even though today's link check flagged the same `fuga.cloud` → `cyso.cloud` redirect.

## Needs a human call

**Today's link check failed on three timeouts, not errors** ([run 32934605279](https://github.com/jmbarrancoml/awesome-european-ai/actions/runs/32934605279)): `eurollm.io`, `tilde.ai` and `tilde.ai/tildeopen-llm/`. The run reported 0 errors and 0 unknown — 228 of 242 unique URLs succeeded. Both sites are demonstrably alive:

- EuroLLM shipped **EuroLLM-22B** with [Instituto Superior Técnico](``https://tecnico.ulisboa.pt/en/news/eurollm-22b-open-european-artificial-intelligence-model-launched-with-participation-of-tecnico/``) and has an EuroHPC extreme-access project starting in 2026.
- Tilde [launched a TildeOpen-based translation platform on 26 February 2026](https://eng.lsm.lv/article/society/education/26.02.2026-latvian-tilde-boasts-new-ai-translation-platform.a636457/) covering 34 European languages.

The same three URLs passed the scheduled run on 2026-08-25, so this looks like a one-day runner-side timeout rather than a dead host. I could not verify by hand — this sandbox has no outbound network. **Leaving both entries and `.lycheeignore` untouched.** If the timeouts recur for a few consecutive mornings, they belong in the "temporary network issues (verified manually)" block of `.lycheeignore`, but one morning is not evidence.

---

`python3 scripts/check-sync.py` passes: README and `data/` agree, Applied AI now 38 entries.
