### PR TITLE
Daily sweep 2026-08-27

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,11 @@ Companies applying AI to specific domains.
 | [Jua](https://jua.ai) | 🇨🇭 Switzerland | Weather | EPT-2 physics model for energy forecasting |
 | [TWAICE](https://www.twaice.com) | 🇩🇪 Germany | Batteries | Predictive analytics for grid storage and EVs |
 | [Ecorobotix](https://ecorobotix.com) | 🇨🇭 Switzerland | Agriculture | Vision-guided ultra-high precision spraying |
+| [NEURA Robotics](https://neura-robotics.com) | 🇩🇪 Germany | Robotics | Cognitive robots and the 4NE1 humanoid |
+| [Sereact](https://sereact.ai) | 🇩🇪 Germany | Robotics | Cortex robot foundation model, $110M Series B |
+| [Humanoid](https://thehumanoid.ai) | 🇬🇧 UK | Robotics | HMND 01 humanoids, Europe's first robotics unicorn |
+| [Flexion Robotics](https://flexion.ai) | 🇨🇭 Switzerland | Robotics | Autonomy stack for humanoid robots, $50M Series A |
+| [THEKER](https://theker.ai) | 🇪🇸 Spain | Robotics | AI-native factory robots, $85M Series A |
 
 ### AI infrastructure
 
@@ -135,7 +140,7 @@ Companies building infrastructure for AI workloads.
 | [Scaleway](https://scaleway.com) | 🇫🇷 France | Cloud | GPU instances, European data centres |
 | [Nebius](https://nebius.com) | 🇳🇱 Netherlands | Cloud | AI-focused cloud, ex-Yandex |
 | [Northern Data](https://northerndata.de) | 🇩🇪 Germany | HPC | High-performance computing, RUM Group subsidiary since 2026 |
-| [VSHN](https://vshn.ch) | 🇨🇭 Switzerland | Cloud | Swiss cloud, Kubernetes for AI |
+| [VSHN](https://www.vshn.ch) | 🇨🇭 Switzerland | Cloud | Swiss cloud, Kubernetes for AI |
 | [Berget AI](https://berget.ai) | 🇸🇪 Sweden | Cloud | Sovereign AI infrastructure, GDPR-compliant |
 | [Cortecs](https://cortecs.ai) | 🇪🇺 EU | Inference | European AI gateway, LLM routing |
 | [Axelera AI](https://axelera.ai) | 🇳🇱 Netherlands | Hardware | Europa edge inference chips, €211M raised |
@@ -368,9 +373,9 @@ Alternatives to Google Search.
 
 | Service | Country | Type | Notes |
 |---------|---------|------|-------|
-| [Qwant](https://qwant.com) | 🇫🇷 France | Free | Uses Bing, building own index with Ecosia |
-| [Ecosia](https://ecosia.org) | 🇩🇪 Germany | Free | Uses Bing, plants trees, building own index with Qwant |
-| [Startpage](https://startpage.com) | 🇳🇱 Netherlands | Free | Google results without tracking |
+| [Qwant](https://qwant.com) | 🇫🇷 France | Free | Co-owns Staan index, live in France and Germany |
+| [Ecosia](https://ecosia.org) | 🇩🇪 Germany | Free | Plants trees, co-owns Staan index with Qwant |
+| [Startpage](https://startpage.com) | 🇳🇱 Netherlands | Free | Google results without tracking, System1 holds majority |
 | [SearXNG](https://searxng.org) | 🇪🇺 EU | Open source | Metasearch, self-hostable |
 | [Mojeek](https://mojeek.com) | 🇬🇧 UK | Free | Independent index, no tracking |
 

--- a/data/companies.json
+++ b/data/companies.json
@@ -577,6 +577,46 @@
       "country_code": "CH",
       "focus": "Agriculture",
       "notes": "Vision-guided ultra-high precision spraying"
+    },
+    {
+      "name": "NEURA Robotics",
+      "url": "https://neura-robotics.com",
+      "country": "Germany",
+      "country_code": "DE",
+      "focus": "Robotics",
+      "notes": "Cognitive robots and the 4NE1 humanoid"
+    },
+    {
+      "name": "Sereact",
+      "url": "https://sereact.ai",
+      "country": "Germany",
+      "country_code": "DE",
+      "focus": "Robotics",
+      "notes": "Cortex robot foundation model, $110M Series B"
+    },
+    {
+      "name": "Humanoid",
+      "url": "https://thehumanoid.ai",
+      "country": "UK",
+      "country_code": "GB",
+      "focus": "Robotics",
+      "notes": "HMND 01 humanoids, Europe's first robotics unicorn"
+    },
+    {
+      "name": "Flexion Robotics",
+      "url": "https://flexion.ai",
+      "country": "Switzerland",
+      "country_code": "CH",
+      "focus": "Robotics",
+      "notes": "Autonomy stack for humanoid robots, $50M Series A"
+    },
+    {
+      "name": "THEKER",
+      "url": "https://theker.ai",
+      "country": "Spain",
+      "country_code": "ES",
+      "focus": "Robotics",
+      "notes": "AI-native factory robots, $85M Series A"
     }
   ],
   "infrastructure": [
@@ -646,7 +686,7 @@
     },
     {
       "name": "VSHN",
-      "url": "https://vshn.ch",
+      "url": "https://www.vshn.ch",
       "country": "Switzerland",
       "country_code": "CH",
       "focus": "Cloud",


### PR DESCRIPTION
Audited today's slice of 25 entries (the European alternatives block — analytics, search, VPN and security — plus foundation models). Search angle for new entries: **European robotics and physical AI**, a segment the list covered with a single entry (Gideon Brothers) until now.

## Additions

- **[NEURA Robotics](https://neura-robotics.com)** 🇩🇪 — Neura Robotics GmbH, Metzingen, Baden-Württemberg, District Court of Stuttgart HRB 768826. Cognitive and collaborative robots plus the 4NE1 humanoid; ~$1.2B Series C in March 2026 and a January 2026 humanoid partnership with Bosch. Production stays in Metzingen; the Zurich site opened in 2025 is a development office, not a headquarters move.
- **[Sereact](https://sereact.ai)** 🇩🇪 — Sereact GmbH, Stuttgart, a 2021 spin-out from the University of Stuttgart. Its Cortex vision-language-action foundation model lets warehouse and industrial robots take natural-language instructions. $110M Series B led by Headline, April 2026; the new Boston office is an expansion, not a relocation.
- **[Humanoid](https://thehumanoid.ai)** 🇬🇧 — registered at 5 Merchant Square, London W2 1AY, founded 2024. HMND 01 wheeled and bipedal robots with the KinetIQ stack. €133M Series A at a €1.1B valuation in July 2026 made it Europe's first pure-play humanoid robotics unicorn; proof of concept run in Bosch's logistics site at Bühl.
- **[Flexion Robotics](https://flexion.ai)** 🇨🇭 — Flexion Robotics AG, Affolternstrasse 42, 8050 Zurich, per the imprint on its own site. Simulation and reinforcement-learning autonomy stack for humanoid platforms, from ETH Zurich and NVIDIA alumni. $50M Series A led by DST Global with NVentures, November 2025.
- **[THEKER](https://theker.ai)** 🇪🇸 — THEKER ROBOTICS S.L., Barcelona, listed on the Catalonia Startup Hub register. AI-native general-purpose factory robots delivered as robot-as-a-service, already deployed in European production lines. $85M Series A led by CRV in June 2026, Europe's largest robotics Series A.

## Corrections

- **VSHN** — URL moved from `https://vshn.ch` to `https://www.vshn.ch`. The apex domain is the only error in the daily link check (`[401] https://vshn.ch/ | Rejected status code: 401 Unauthorized`, [run 32937533623](https://github.com/jmbarrancoml/awesome-european-ai/actions/runs/32937533623)); the `www` host is the one VSHN itself publishes and serves its blog and contact pages from. The company is in no trouble: VSHN AG, Zurich, UID CHE-275.566.226, active in the Swiss commercial register and sponsoring DevOpsDays Zurich in May 2026. This is a host fix, not a bot-protection skip, so it stays out of `.lycheeignore` and the link check on this PR is the test.
- **Qwant** and **Ecosia** — the shared index they were "building" now exists and ships. Their Paris joint venture European Search Perspective (50/50) launched the Staan index, serving French queries from 2025 and German queries since July 2026. Notes updated accordingly.
- **Startpage** — note now records that Surfboard Holding BV, the Dutch entity behind Startpage, has been majority-owned by System1's Privacy One Group since 2019. The entry stays: this is the Silo AI shape, a European entity trading under a foreign parent, and the list's convention is to carry the parent in the note rather than drop the row.

## Needs a human call

- **Poolside** — currently flagged 🇫🇷 France, and I could not settle whether that still holds. The August 2023 seed round was reported as a relocation from San Francisco to Paris, and Dun & Bradstreet lists a POOLSIDE AI entity in Paris 2, Île-de-France. Against that, more recent profiles put the headquarters back at 548 Market Street, San Francisco, with Paris described as a branch the team visits for a concentrated work week each month, and one report quotes the company saying it remains US-headquartered with a team across both continents. I could not reach poolside.ai's own about page from this sandbox to check which the company currently claims, and the criteria say a European office is not enough on its own. Left untouched pending someone who can open that page — if it reads San Francisco, this is the Cognite case and the entry should go.

## Notes for the reviewer

Eight earlier sweep PRs are still open and unmerged (#8, #9, #10, #11, #12, #13, #14, #16), plus community PR #15. Nothing here duplicates their proposals — I checked their contents before choosing today's angle, and the robotics entries above do not overlap with the defence robotics proposed in #10.

`python3 scripts/check-sync.py` passes: README.md and `data/companies.json` agree, Applied AI now at 39 entries.
