### PR TITLE
Daily sweep 2026-08-28

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Companies building foundation models (LLMs, image, audio).
 | [Stability AI](https://stability.ai) | 🇬🇧 UK | Image | Stable Diffusion, open source focus |
 | [NXAI](https://nx-ai.com) | 🇦🇹 Austria | xLSTM | TiRex time series model, founded by Sepp Hochreiter |
 | [Domyn](https://www.domyn.com) | 🇮🇹 Italy | LLMs | Sovereign models, leads EU EUROPA consortium, formerly iGenius |
-| [Almawave](https://www.almawave.com) | 🇮🇹 Italy | LLMs | Velvet open-weight models, trained on Leonardo |
+| [Almawave](https://www.almawave.com) | 🇮🇹 Italy | LLMs | Velvet open-weight models, Almaviva subsidiary since 2025 |
 | [Tilde](https://tilde.ai) | 🇱🇻 Latvia | LLMs | TildeOpen, trained equally on 34 European languages |
 | [OpenEuroLLM](https://openeurollm.eu) | 🇪🇺 EU | Open models | €37.4M Digital Europe project, 20 partners |
 
@@ -74,12 +74,11 @@ Companies applying AI to specific domains.
 | [Tractable](https://tractable.ai) | 🇬🇧 UK | Insurance | AI for accident and disaster recovery |
 | [Seedtag](https://seedtag.com) | 🇪🇸 Spain | Advertising | Contextual AI for in-image advertising |
 | [Sherpa.ai](https://sherpa.ai) | 🇪🇸 Spain | Assistants | Predictive AI assistant, federated learning |
-| [Clarity AI](https://clarity.ai) | 🇪🇸 Spain | Sustainability | AI for ESG and sustainability analysis |
 | [FacePhi](https://facephi.com) | 🇪🇸 Spain | Biometrics | Facial recognition for banking/KYC |
 | [Photoroom](https://photoroom.com) | 🇫🇷 France | Image editing | AI background removal and editing |
 | [Synthesia](https://synthesia.io) | 🇬🇧 UK | Video | AI video generation with avatars |
 | [Sana Labs](https://sanalabs.com) | 🇸🇪 Sweden | Education | AI-powered learning platform, acquired by Workday |
-| [BenevolentAI](https://www.benevolent.com) | 🇬🇧 UK | Drug discovery | AI for drug development |
+| [BenevolentAI](https://www.benevolent.com) | 🇬🇧 UK | Drug discovery | AI for drug development, taken private in 2025 |
 | [Legora](https://legora.com) | 🇸🇪 Sweden | Legal | AI legal assistant, formerly Leya |
 | [Robin AI](https://robinai.com) | 🇬🇧 UK | Legal | AI contract review |
 | [Noxtua](https://noxtua.com) | 🇩🇪 Germany | Legal | Sovereign legal AI for German and EU law |
@@ -125,6 +124,11 @@ Companies applying AI to specific domains.
 | [Humanoid](https://thehumanoid.ai) | 🇬🇧 UK | Robotics | HMND 01 humanoids, Europe's first robotics unicorn |
 | [Flexion Robotics](https://flexion.ai) | 🇨🇭 Switzerland | Robotics | Autonomy stack for humanoid robots, $50M Series A |
 | [THEKER](https://theker.ai) | 🇪🇸 Spain | Robotics | AI-native factory robots, $85M Series A |
+| [Hawk](https://hawk.ai) | 🇩🇪 Germany | Financial crime | AI anti-money laundering and fraud monitoring |
+| [Taktile](https://taktile.com) | 🇩🇪 Germany | Risk decisioning | Automated credit, fraud and compliance decisions |
+| [Resistant AI](https://resistant.ai) | 🇨🇿 Czechia | Fraud | Detects document forgery and transaction fraud |
+| [ComplyAdvantage](https://complyadvantage.com) | 🇬🇧 UK | Compliance | AI-native financial crime risk screening |
+| [Lucinity](https://lucinity.com) | 🇮🇸 Iceland | Financial crime | Human AI copilot for AML investigations |
 
 ### AI infrastructure
 

--- a/data/companies.json
+++ b/data/companies.json
@@ -118,7 +118,7 @@
       "country": "Italy",
       "country_code": "IT",
       "focus": "LLMs",
-      "notes": "Velvet open-weight models, trained on Leonardo"
+      "notes": "Velvet open-weight models, Almaviva subsidiary since 2025"
     },
     {
       "name": "Tilde",
@@ -211,14 +211,6 @@
       "notes": "Predictive AI assistant, federated learning"
     },
     {
-      "name": "Clarity AI",
-      "url": "https://clarity.ai",
-      "country": "Spain",
-      "country_code": "ES",
-      "focus": "Sustainability",
-      "notes": "AI for ESG and sustainability analysis"
-    },
-    {
       "name": "FacePhi",
       "url": "https://facephi.com",
       "country": "Spain",
@@ -256,7 +248,7 @@
       "country": "UK",
       "country_code": "GB",
       "focus": "Drug discovery",
-      "notes": "AI for drug development"
+      "notes": "AI for drug development, taken private in 2025"
     },
     {
       "name": "Legora",
@@ -617,6 +609,46 @@
       "country_code": "ES",
       "focus": "Robotics",
       "notes": "AI-native factory robots, $85M Series A"
+    },
+    {
+      "name": "Hawk",
+      "url": "https://hawk.ai",
+      "country": "Germany",
+      "country_code": "DE",
+      "focus": "Financial crime",
+      "notes": "AI anti-money laundering and fraud monitoring"
+    },
+    {
+      "name": "Taktile",
+      "url": "https://taktile.com",
+      "country": "Germany",
+      "country_code": "DE",
+      "focus": "Risk decisioning",
+      "notes": "Automated credit, fraud and compliance decisions"
+    },
+    {
+      "name": "Resistant AI",
+      "url": "https://resistant.ai",
+      "country": "Czechia",
+      "country_code": "CZ",
+      "focus": "Fraud",
+      "notes": "Detects document forgery and transaction fraud"
+    },
+    {
+      "name": "ComplyAdvantage",
+      "url": "https://complyadvantage.com",
+      "country": "UK",
+      "country_code": "GB",
+      "focus": "Compliance",
+      "notes": "AI-native financial crime risk screening"
+    },
+    {
+      "name": "Lucinity",
+      "url": "https://lucinity.com",
+      "country": "Iceland",
+      "country_code": "IS",
+      "focus": "Financial crime",
+      "notes": "Human AI copilot for AML investigations"
     }
   ],
   "infrastructure": [


### PR DESCRIPTION
Search angle for new entries: **European AI for financial crime, risk and compliance**. Slice audited: 25 entries, day 240 (foundation models tail plus the first two thirds of Applied AI).

## Additions

- **[Hawk](https://hawk.ai)** — Hawk AI GmbH, founded 2018, headquartered in Munich with offices in London, New York, Riyadh and Singapore. Raised a $56M Series C led by One Peak, bringing total funding to $193M. Sources: [FinTech Futures](https://www.fintechfutures.com/venture-capital-funding/german-aml-fintech-hawk-raises-56m-series-c-led-by-one-peak), [Finovate](https://finovate.com/hawk-raises-56-million-in-series-c-funding-to-help-banks-fight-financial-crime/).
- **[Taktile](https://taktile.com)** — headquartered in Berlin, with New York and London offices. Raised a $110M Series C in 2026 for its agentic decision platform for banks and insurers; $184M total. Sources: [PYMNTS](``https://www.pymnts.com/news/investment-tracker/2026/taktile-raises-110-million-to-automate-high-stakes-banking-and-insurance-decisions/),`` [Taktile Series B announcement](https://taktile.com/articles/taktile-raises-54m-series-b).
- **[Resistant AI](https://resistant.ai)** — founded in Prague in 2019 by Martin Rehak, 100+ staff across Prague, London and New York. Raised a $25M Series B led by DTCP in October 2025. First Czech entry in the list. Sources: [Tech.eu](``https://tech.eu/2025/10/13/resistant-ai-raises-25m-series-b-to-fortify-fintechs-and-ai-agents-against-financial-crime/),`` [EU-Startups](``https://www.eu-startups.com/2025/10/resistant-ai-out-of-czechia-tackles-fincrime-and-fraud-prevention-with-new-e21-million/).``
- **[ComplyAdvantage](https://complyadvantage.com)** — London-headquartered, with hubs in New York, Lisbon, Singapore and Cluj-Napoca. Launched its Mesh platform in late 2025 and named to the 2026 AIFinTech100. Sources: [company press page](``https://complyadvantage.com/press-media/complyadvantage-makes-the-2026-aifintech100-list-for-its-ai-native-approach-to-financial-crime-compliance/),`` [FinTech Global](https://fintech.global/2025/10/29/complyadvantage-unveils-mesh-to-fight-fincrime/).
- **[Lucinity](https://lucinity.com)** — founded in Reykjavík in 2018 by Guðmundur Kristjánsson, "Human AI" AML platform with Microsoft and Oracle integrations. First Icelandic entry in the list. Sources: [Lucinity](https://lucinity.com/), [byFounders portfolio](https://www.byfounders.vc/portfolio/lucinity).

## Corrections

- **Almawave** — Almaviva S.p.A. completed its voluntary tender offer in December 2025, taking 97.91% of the share capital and delisting Almawave from Euronext Growth Milan. Almaviva is Italian, so the entry stays with the acquisition recorded in its note (the Silo AI / Sana Labs pattern). Sources: [TipRanks](https://www.tipranks.com/news/company-announcements/almaviva-completes-acquisition-and-delisting-of-almawave), [The Globe and Mail](https://www.theglobeandmail.com/investing/markets/markets-news/Tipranks/36493337/almaviva-completes-acquisition-and-delisting-of-almawave/).
- **BenevolentAI** — delisted from Euronext Amsterdam on 13 March 2025 by merging into Osaka Holdings S.à r.l., which then converted to an S.A. and took the BenevolentAI name. Still operating from London as a private techbio. Sources: [BenevolentAI press release](``https://www.benevolent.com/news-and-media/press-releases-and-in-media/proposed-delisting-merger-benevolentai-osaka-holdings-s-rl-and-publication-notice-extraordinary-general-meeting/),`` [Euronext](https://live.euronext.com/en/products/equities/company-news/2025-03-12-result-extraordinary-general-meeting-and-delisting), [MedCity News](https://medcitynews.com/2024/12/ai-benevolentai-restructuring-techbio-drug-discovery-bai/).

## Removals

- **Clarity AI** — founded in Madrid in 2017, but the group parent is Clarity AI Inc., headquartered in New York; the Spanish entity is a subsidiary, registered as CLARITY AI EUROPE, S.L. (Registro Mercantil de Madrid, NIF B87752093, Meléndez Valdés 16, 28015 Madrid). Under CONTRIBUTING.md a European office and European founders are not enough on their own — the same reading that removed Aizon (Bigfinite, Inc., San Francisco). Sources: [Bloomberg — Clarity AI Inc](https://www.bloomberg.com/profile/company/1695300D:US), [LEI register for CLARITY AI EUROPE, S.L.](https://www.leinumber.com/leicert/9598006WJNT4MAHD9F12/), [NorthData](https://www.northdata.com/Clarity%20AI%20Europe%20SL,%20Madrid/NIF%20B87752093).

## Needs a human call

- **Robin AI** (Applied AI, UK) — the business appears to have been broken up, but the entry does not meet the stated removal test, so it is untouched here. What happened: a planned $50M round collapsed in October 2025 and roughly a third of staff were cut ([Artificial Lawyer](https://www.artificiallawyer.com/2025/10/27/robin-ai-lays-off-staff-as-growth-disappoints/)); the company sought a rescue buyer ([City AM](https://www.cityam.com/nik-storonsky-backed-robin-ai-seeks-rescue-buyer-after-fundraise-falls-short/)); about 75 managed-services staff moved to the law firm Scissero in December 2025 ([Law.com](https://www.law.com/legaltechnews/2025/12/11/why-ai-forward-law-firm-scissero-bought-robin-ais-managed-services-team-/), [Global Legal Post](https://www.globallegalpost.com/news/scissero-buys-managed-services-team-of-rival-robin-ai-264599795)); and Microsoft acqui-hired the engineering team for its Word group in January 2026, explicitly without buying the company ([Artificial Lawyer](https://www.artificiallawyer.com/2026/01/09/microsoft-to-acqui-hire-robin-ai-tech-team/), [Legal IT Insider](https://legaltechnology.com/2026/01/12/microsoft-hires-raft-of-robin-ai-engineers-to-bolster-its-word-team/)). Against that: ROBIN AI LIMITED (Companies House 11400135) still shows as active with no insolvency filing I could confirm, and robinai.com still resolves — it passed yesterday's link check rather than redirecting to a parent. Your call whether "discontinued" already applies.
- **Stability AI** (Foundation models, UK) — Stability AI has closed its London office and shifted its focus to the US, operating from Los Angeles ([Tech.eu, 25 August 2026](https://tech.eu/2026/08/25/stabiityai-raises-76m-with-warner-and-sony-investing/)), in the same round that raised $76M from Sony, Universal, Warner and EA. That is the Cognite pattern, but STABILITY AI LTD (Companies House 12295325) is still the UK-registered entity and the criteria read "incorporated **or** headquartered in Europe", so I have left it alone rather than guess which half you weight. Left untouched pending your decision.
- **DeepDNA** (Applied AI, EU) — checked again this round, unchanged: still no findable register entry or imprint, already on the EU fallback flag. No action taken.

## Link check

Yesterday's scheduled `links.yml` run ([33091809581](https://github.com/jmbarrancoml/awesome-european-ai/actions/runs/33091809581)) reported exactly one error out of 242 unique URLs: `https://vshn.ch/` returning 415 Unsupported Media Type. That fix is already proposed in the still-open [#17](https://github.com/jmbarrancoml/awesome-european-ai/pull/17) (move to `https://www.vshn.ch`), so it is not duplicated here.

Note that sweep PRs [#8](https://github.com/jmbarrancoml/awesome-european-ai/pull/8) through [#17](https://github.com/jmbarrancoml/awesome-european-ai/pull/17) are all still open and unmerged, along with the community PR [#15](https://github.com/jmbarrancoml/awesome-european-ai/pull/15). Nothing proposed here overlaps with them.
