### PR TITLE
Daily sweep 2026-08-29

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -22,6 +22,11 @@ https://parloa.com
 # An independent search engine defending its index from datacentre traffic:
 # 0.3s from a normal connection, 503 or timeout from the runner
 https://mojeek.com
+# Resets the connection on the runner rather than answering with a status code,
+# so --accept cannot cover it. The initiative is trading normally: appliedAI
+# Initiative GmbH, District Court of Munich HRB 255519, events listed into
+# September 2026
+https://www.appliedai.de
 
 # Sites with temporary network issues (verified manually)
 https://builder.ai

--- a/README.md
+++ b/README.md
@@ -129,6 +129,9 @@ Companies applying AI to specific domains.
 | [Resistant AI](https://resistant.ai) | 🇨🇿 Czechia | Fraud | Detects document forgery and transaction fraud |
 | [ComplyAdvantage](https://complyadvantage.com) | 🇬🇧 UK | Compliance | AI-native financial crime risk screening |
 | [Lucinity](https://lucinity.com) | 🇮🇸 Iceland | Financial crime | Human AI copilot for AML investigations |
+| [Darktrace](https://darktrace.com) | 🇬🇧 UK | Cybersecurity | Self-learning threat detection, Thoma Bravo owned |
+| [Filigran](https://filigran.io) | 🇫🇷 France | Cybersecurity | Threat intelligence and breach simulation, creators of OpenCTI |
+| [Hadrian](https://hadrian.io) | 🇳🇱 Netherlands | Cybersecurity | Agentic offensive security and exposure management |
 
 ### AI infrastructure
 
@@ -254,6 +257,8 @@ Notable open source AI projects from European developers or companies.
 | [Meilisearch](https://github.com/meilisearch/meilisearch) | 🇫🇷 France | Search engine in Rust with hybrid vector search |
 | [ZenML](https://github.com/zenml-io/zenml) | 🇩🇪 Germany | MLOps framework for reproducible ML pipelines |
 | [Rerun](https://github.com/rerun-io/rerun) | 🇸🇪 Sweden | Visualisation and data stack for robotics |
+| [OpenCTI](https://github.com/OpenCTI-Platform/opencti) | 🇫🇷 France | Threat intelligence platform by Filigran |
+| [CrowdSec](https://github.com/crowdsecurity/crowdsec) | 🇫🇷 France | Crowdsourced intrusion prevention and IP reputation |
 
 ---
 

--- a/data/companies.json
+++ b/data/companies.json
@@ -649,6 +649,30 @@
       "country_code": "IS",
       "focus": "Financial crime",
       "notes": "Human AI copilot for AML investigations"
+    },
+    {
+      "name": "Darktrace",
+      "url": "https://darktrace.com",
+      "country": "UK",
+      "country_code": "GB",
+      "focus": "Cybersecurity",
+      "notes": "Self-learning threat detection, Thoma Bravo owned"
+    },
+    {
+      "name": "Filigran",
+      "url": "https://filigran.io",
+      "country": "France",
+      "country_code": "FR",
+      "focus": "Cybersecurity",
+      "notes": "Threat intelligence and breach simulation, creators of OpenCTI"
+    },
+    {
+      "name": "Hadrian",
+      "url": "https://hadrian.io",
+      "country": "Netherlands",
+      "country_code": "NL",
+      "focus": "Cybersecurity",
+      "notes": "Agentic offensive security and exposure management"
     }
   ],
   "infrastructure": [

--- a/data/open-source.json
+++ b/data/open-source.json
@@ -208,5 +208,19 @@
     "country": "Sweden",
     "country_code": "SE",
     "description": "Visualisation and data stack for robotics"
+    },
+    {
+    "name": "OpenCTI",
+    "url": "https://github.com/OpenCTI-Platform/opencti",
+    "country": "France",
+    "country_code": "FR",
+    "description": "Threat intelligence platform by Filigran"
+  },
+  {
+    "name": "CrowdSec",
+    "url": "https://github.com/crowdsecurity/crowdsec",
+    "country": "France",
+    "country_code": "FR",
+    "description": "Crowdsourced intrusion prevention and IP reputation"
   }
 ]


### PR DESCRIPTION
Audited 25 entries (applied AI tail and the AI infrastructure block). Search angle for new entries: **European AI for cybersecurity** — a segment with no coverage in the list until now.

## Additions

- **[Darktrace](https://darktrace.com)** — 🇬🇧 UK, applied AI. Darktrace Holdings Ltd, headquartered in Cambridge. Acquired by Thoma Bravo (US) on 1 October 2024, and the offer terms committed to no material change to the Cambridge headquarters or to R&D in the UK and the Netherlands; Thoma Bravo's own January 2026 release still gives Cambridge as the headquarters. European entity intact under a foreign parent, so it stays in on the Silo AI / Sana Labs reading.
- **[Filigran](https://filigran.io)** — 🇫🇷 France, applied AI. Paris. Closed a $58M Series C led by Eurazeo Growth with Deutsche Telekom (T.Capital), Accel and Insight Partners, taking total funding past $100M. Builds OpenCTI and OpenBAS/OpenAEV.
- **[Hadrian](https://hadrian.io)** — 🇳🇱 Netherlands, applied AI. Amsterdam, founded 2021. Agentic AI offensive security and exposure management; took follow-on investment from ABN AMRO Ventures announced 24 January 2026.
- **[OpenCTI](https://github.com/OpenCTI-Platform/opencti)** — 🇫🇷 France, open source. Open threat intelligence platform, owned and developed by Filigran (Paris). Follows the existing Deepset/Haystack and Giskard pattern of listing the company and its project separately.
- **[CrowdSec](https://github.com/crowdsecurity/crowdsec)** — 🇫🇷 France, open source. MIT-licensed collaborative intrusion prevention engine. Entity evidence: CrowdSec SAS, RCS Nanterre 880 140 496, registered office 20 rue Maurice Arnoux, 92120 Montrouge; EU VAT FR20880140496.

## Corrections

- **`.lycheeignore`: exclude `https://www.appliedai.de`.** It is the only URL the link check rejected, and it failed both of yesterday's runs ([06:17](https://github.com/jmbarrancoml/awesome-european-ai/actions/runs/33147422733) and [17:11](https://github.com/jmbarrancoml/awesome-european-ai/actions/runs/33193483298)) with `Network error: Connection reset by peer (os error 104)` — a reset rather than a status code, so the workflow's `--accept 200,202,206,403,429` cannot cover it. The initiative is trading normally: appliedAI Initiative GmbH, District Court of Munich HRB 255519, offices in Munich and Heilbronn, with events listed on its own site into September 2026. Same reasoning already applied to `parloa.com` and `mojeek.com`.

## Removals

None. All 25 audited entries are still independent, European and operating. Checked in particular: Speechmatics (no acquisition, still Cambridge), Nebius (Amsterdam confirmed as global HQ, new office opened February 2026), Veriff (acquirer rather than target — bought Vespia in February 2026), Feedzai (Coimbra, acquired Demyst, not acquired itself), Corti, Owkin (spun Waiv out, parent unaffected), Nuritas (UK subsidiary active, posts to August 2026), Multiverse Computing (San Sebastián HQ, $570M Series C), DRUID AI, Gideon Brothers, Robovision, SiPearl (Rhea1 powered on May 2026), PolyAI, Tekever (Lisbon HQ) and Berget AI.

## Needs a human call

- **The sweep backlog, not an entry.** PRs #8 through #18 are all open and unmerged, the oldest since 19 August, alongside the external contribution #15. Nothing has merged into `main` in ten days, so each sweep now proposes against a base that is missing everything the previous ten proposed. The corrections in those PRs are the ones that age worst — renamed domains and stale ownership notes are wrong in the published README for as long as they sit unmerged. This branch does not duplicate anything already proposed in them; I checked each diff first.
