### PR TITLE
Daily sweep 2026-08-30

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Companies applying AI to specific domains.
 | [Noxtua](https://noxtua.com) | 🇩🇪 Germany | Legal | Sovereign legal AI for German and EU law |
 | [Jimini AI](https://www.jimini.ai) | 🇫🇷 France | Legal | AI copilot for law firms |
 | [Luminance](https://www.luminance.com) | 🇬🇧 UK | Legal | Contract analysis and legal diligence |
-| [Wayve](https://wayve.ai) | 🇬🇧 UK | Autonomous driving | End-to-end driving models, no HD maps |
+| [Wayve](https://wayve.ai) | 🇬🇧 UK | Autonomous driving | End-to-end driving models, $8.6B Series D valuation |
 | [Quantexa](https://www.quantexa.com) | 🇬🇧 UK | Decision intelligence | Entity resolution for banks and government |
 | [PolyAI](https://poly.ai) | 🇬🇧 UK | Voice agents | Customer service assistants over the phone |
 | [Owkin](https://www.owkin.com) | 🇫🇷 France | Biotech | AI for drug discovery and diagnostics |
@@ -132,6 +132,11 @@ Companies applying AI to specific domains.
 | [Darktrace](https://darktrace.com) | 🇬🇧 UK | Cybersecurity | Self-learning threat detection, Thoma Bravo owned |
 | [Filigran](https://filigran.io) | 🇫🇷 France | Cybersecurity | Threat intelligence and breach simulation, creators of OpenCTI |
 | [Hadrian](https://hadrian.io) | 🇳🇱 Netherlands | Cybersecurity | Agentic offensive security and exposure management |
+| [Shippeo](https://www.shippeo.com) | 🇫🇷 France | Supply chain | Real-time multimodal transport visibility and ETAs |
+| [Transmetrics](https://transmetrics.ai) | 🇧🇬 Bulgaria | Logistics | Predictive planning for logistics fleets and freight |
+| [Einride](https://www.einride.tech) | 🇸🇪 Sweden | Freight | Electric and autonomous freight, Nasdaq listed 2026 |
+| [MOTOR Ai](https://motor-ai.com) | 🇩🇪 Germany | Autonomous driving | Certifiable Level 4 software, approved for German roads |
+| [Oxa](https://oxa.tech) | 🇬🇧 UK | Autonomous driving | Self-driving software for industrial and commercial fleets |
 
 ### AI infrastructure
 

--- a/data/companies.json
+++ b/data/companies.json
@@ -296,7 +296,7 @@
       "country": "UK",
       "country_code": "GB",
       "focus": "Autonomous driving",
-      "notes": "End-to-end driving models, no HD maps"
+      "notes": "End-to-end driving models, $8.6B Series D valuation"
     },
     {
       "name": "Quantexa",
@@ -673,6 +673,46 @@
       "country_code": "NL",
       "focus": "Cybersecurity",
       "notes": "Agentic offensive security and exposure management"
+    },
+    {
+      "name": "Shippeo",
+      "url": "https://www.shippeo.com",
+      "country": "France",
+      "country_code": "FR",
+      "focus": "Supply chain",
+      "notes": "Real-time multimodal transport visibility and ETAs"
+    },
+    {
+      "name": "Transmetrics",
+      "url": "https://transmetrics.ai",
+      "country": "Bulgaria",
+      "country_code": "BG",
+      "focus": "Logistics",
+      "notes": "Predictive planning for logistics fleets and freight"
+    },
+    {
+      "name": "Einride",
+      "url": "https://www.einride.tech",
+      "country": "Sweden",
+      "country_code": "SE",
+      "focus": "Freight",
+      "notes": "Electric and autonomous freight, Nasdaq listed 2026"
+    },
+    {
+      "name": "MOTOR Ai",
+      "url": "https://motor-ai.com",
+      "country": "Germany",
+      "country_code": "DE",
+      "focus": "Autonomous driving",
+      "notes": "Certifiable Level 4 software, approved for German roads"
+    },
+    {
+      "name": "Oxa",
+      "url": "https://oxa.tech",
+      "country": "UK",
+      "country_code": "GB",
+      "focus": "Autonomous driving",
+      "notes": "Self-driving software for industrial and commercial fleets"
     }
   ],
   "infrastructure": [


### PR DESCRIPTION
Audited today's 25-entry slice (the European alternatives section plus Mistral AI) and searched a new angle: **European AI for logistics, supply chain and mobility**.

## Additions

- **[Shippeo](https://www.shippeo.com)** 🇫🇷 — Paris (60 rue d'Hauteville), real-time multimodal transport visibility. $138M raised, La French Tech 120, and has acquired German supply chain automation firm Logward. Active and independent.
- **[Transmetrics](https://transmetrics.ai)** 🇧🇬 — Sofia, predictive planning for logistics fleets. In the European Innovation Council fund portfolio as *Transmetrics AD* (EIC company page), ~48 staff, launched FleetMetrics in August 2026. Customers include DHL, DB Schenker and DPD.
- **[Einride](https://www.einride.tech)** 🇸🇪 — Stockholm (65 Regeringsgatan), electric and autonomous freight. Einride AB completed its business combination with Legato Merger Corp. III and began trading on Nasdaq as `ENRD` on 10 June 2026; operational HQ stays in Stockholm, so it qualifies on the headquarters test the same way Darktrace does under Thoma Bravo.
- **[MOTOR Ai](https://motor-ai.com)** 🇩🇪 — Berlin, Level 4 autonomous driving built in-house since 2017. $20M / €17.1M seed led by Segenia Capital and eCAPITAL; the Kraftfahrt-Bundesamt has granted nationwide public-road testing permission (highways excluded).
- **[Oxa](https://oxa.tech)** 🇬🇧 — Oxford, self-driving software for industrial and commercial fleets. Oxford Robotics Institute spin-out (2014); $103M first close of its Series D in March 2026.

## Corrections

- **Wayve** — note refreshed from "no HD maps" to the February 2026 Series D. Wayve's own press page and CNBC both put the round at an $8.6B post-money valuation; the round is variously reported as $1.2B and, after the extension, $1.5B, so the note records the valuation rather than the amount.

## Removals

None. Nothing in today's slice showed an insolvency, a shutdown, a redirect to a foreign parent, or a headquarters move out of Europe.

## Needs a human call

- **Mistral AI valuation.** The README says €11.7B, which is the confirmed September 2025 Series C. For 2026 the reporting does not agree: TechCrunch (12 June 2026) and Bloomberg describe a €3B Series D at ~€20B as *rumoured* and "at an early stage, terms subject to change, Mistral declined to comment"; one aggregator (aiexpert.news) states the round *closed* at €20B with EQT's Scaleup Europe Fund; a Samsung investment of up to €1B at the same valuation was reported on 22 July 2026, also as talks. The confirmed 2026 event is an $830M debt facility from seven banks (30 March 2026). I have left €11.7B in place rather than write a number that only a weak source supports — worth a look if you have a primary source.

## Slice audit — checked and unchanged

Anytype (Any Association, Zug), XWiki SAS (Paris RCS 477 865 281), Standard Notes (still a distinct product and brand under Proton, not sunset), Plausible (Tartu, bootstrapped, no acquisition), Pirsch (Emvi Software GmbH, Rheda-Wiedenbrück), Simple Analytics (Netherlands, self-funded), Mojeek (Brighton, own index), IVPN (Gibraltar; Privatus Limited renamed IVPN Limited, jurisdiction and ownership unchanged — the existing entry already carries no company name, so no edit needed), Passbolt (Esch-sur-Alzette, $8M Series A January 2025, 40 staff). Qwant, Ecosia, Startpage and Soverin were corrected in the 26–27 August sweeps and were not re-searched.

## Repo state

- `python3 scripts/check-sync.py` passes; Applied AI now 72 entries.
- The last `links.yml` run on `main` (run 141, 29 August) was green, so there were no broken links to fix this round. No scheduled run had appeared for 2026-08-30 at 06:10 UTC.
- No open issues. PR #15 ("Add LLM Tech to AI infrastructure", from an outside contributor) is still open with its link check sitting at `action_required` — it needs a maintainer to approve the workflow run. It does not overlap with anything proposed here.
