### PR TITLE
docs: add SpecterAI to applied AI companies

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Companies applying AI to specific domains.
 | [Legora](https://legora.com) | 🇸🇪 Sweden | Legal | AI legal assistant, formerly Leya |
 | [Robin AI](https://robinai.com) | 🇬🇧 UK | Legal | AI contract review |
 | [Noxtua](https://noxtua.com) | 🇩🇪 Germany | Legal | Sovereign legal AI for German and EU law |
+| [SpecterAI](https://specterlaw.ai) | 🇷🇴 Romania | Legal | German legal AI grounded in cited statutes and case law |
 | [Jimini AI](https://www.jimini.ai) | 🇫🇷 France | Legal | AI copilot for law firms |
 | [Luminance](https://www.luminance.com) | 🇬🇧 UK | Legal | Contract analysis and legal diligence |
 | [Wayve](https://wayve.ai) | 🇬🇧 UK | Autonomous driving | End-to-end driving models, no HD maps |

--- a/data/companies.json
+++ b/data/companies.json
@@ -275,6 +275,14 @@
       "notes": "Sovereign legal AI for German and EU law"
     },
     {
+      "name": "SpecterAI",
+      "url": "https://specterlaw.ai",
+      "country": "Romania",
+      "country_code": "RO",
+      "focus": "Legal",
+      "notes": "German legal AI grounded in cited statutes and case law"
+    },
+    {
       "name": "Jimini AI",
       "url": "https://www.jimini.ai",
       "country": "France",


### PR DESCRIPTION
Adds SpecterAI to the Applied AI company list alongside the existing European legal AI entries. The matching JSON record keeps the generated data source in sync and identifies Romania as the incorporating country, supported by the public [ROLIDE SRL imprint](https://specterlaw.ai/imprint).

Affiliation disclosure: I am submitting this entry on behalf of SpecterAI.
