### PR TITLE
Daily sweep 2026-09-01

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Companies applying AI to specific domains.
 | [Delian Alliance Industries](https://www.delian.ai) | 🇬🇷 Greece | Defence | Autonomous surveillance towers, border threat detection |
 | [Aignostics](https://www.aignostics.com) | 🇩🇪 Germany | Pathology | Atlas pathology foundation models, Charité spin-off |
 | [Quibim](https://quibim.com) | 🇪🇸 Spain | Medical imaging | Quantitative imaging biomarkers for precision medicine |
-| [Oxipit](https://oxipit.ai) | 🇱🇹 Lithuania | Radiology | First CE-marked autonomous chest X-ray AI |
+| [Oxipit](https://oxipit.ai) | 🇱🇹 Lithuania | Radiology | First CE-marked autonomous chest X-ray AI, acquired by Sectra |
 | [Turbine](https://turbine.ai) | 🇭🇺 Hungary | Drug discovery | Simulated cell models for virtual experiments |
 | [DoMore Diagnostics](https://www.domorediagnostics.com) | 🇳🇴 Norway | Pathology | Histotype Px predicts colorectal cancer outcomes |
 | [CuspAI](https://cusp.ai) | 🇬🇧 UK | Materials | Search engine for new materials, Cambridge |
@@ -143,6 +143,11 @@ Companies applying AI to specific domains.
 | [Didimo](https://www.didimo.co) | 🇵🇹 Portugal | Digital humans | Automated 3D avatars and game characters |
 | [modl.ai](https://modl.ai) | 🇩🇰 Denmark | Gaming | AI bots for automated game testing |
 | [ai-coustics](https://ai-coustics.com) | 🇩🇪 Germany | Audio | Real-time speech enhancement for voice AI |
+| [Textkernel](https://www.textkernel.com) | 🇳🇱 Netherlands | Recruitment | CV parsing and job matching, acquired by Bullhorn |
+| [HrFlow.ai](https://hrflow.ai) | 🇫🇷 France | HR data | APIs for parsing, tagging and matching HR data |
+| [Retorio](https://www.retorio.com) | 🇩🇪 Germany | Training | AI video simulations for sales and leadership coaching |
+| [bettermarks](https://bettermarks.com) | 🇩🇪 Germany | Education | Adaptive maths courseware for schools |
+| [CENTURY Tech](https://www.century.tech) | 🇬🇧 UK | Education | Personalised learning pathways and teacher analytics |
 
 ### AI infrastructure
 

--- a/data/companies.json
+++ b/data/companies.json
@@ -528,7 +528,7 @@
       "country": "Lithuania",
       "country_code": "LT",
       "focus": "Radiology",
-      "notes": "First CE-marked autonomous chest X-ray AI"
+      "notes": "First CE-marked autonomous chest X-ray AI, acquired by Sectra"
     },
     {
       "name": "Turbine",
@@ -761,6 +761,46 @@
       "country_code": "DE",
       "focus": "Audio",
       "notes": "Real-time speech enhancement for voice AI"
+    },
+    {
+      "name": "Textkernel",
+      "url": "https://www.textkernel.com",
+      "country": "Netherlands",
+      "country_code": "NL",
+      "focus": "Recruitment",
+      "notes": "CV parsing and job matching, acquired by Bullhorn"
+    },
+    {
+      "name": "HrFlow.ai",
+      "url": "https://hrflow.ai",
+      "country": "France",
+      "country_code": "FR",
+      "focus": "HR data",
+      "notes": "APIs for parsing, tagging and matching HR data"
+    },
+    {
+      "name": "Retorio",
+      "url": "https://www.retorio.com",
+      "country": "Germany",
+      "country_code": "DE",
+      "focus": "Training",
+      "notes": "AI video simulations for sales and leadership coaching"
+    },
+    {
+      "name": "bettermarks",
+      "url": "https://bettermarks.com",
+      "country": "Germany",
+      "country_code": "DE",
+      "focus": "Education",
+      "notes": "Adaptive maths courseware for schools"
+    },
+    {
+      "name": "CENTURY Tech",
+      "url": "https://www.century.tech",
+      "country": "UK",
+      "country_code": "GB",
+      "focus": "Education",
+      "notes": "Personalised learning pathways and teacher analytics"
     }
   ],
   "infrastructure": [


### PR DESCRIPTION
Daily sweep for 2026-09-01. The search angle this run was European AI for education, HR and workforce, a segment the list covered with one entry (Sana Labs).

The audit slice was 25 applied AI entries, offset 47, covering defence, earth observation, medical imaging and climate. One entry changed.

## Additions

- **[Textkernel](https://www.textkernel.com)** (Netherlands, Recruitment). Textkernel B.V. is registered in Amsterdam at KVK 59663863, address Asterweg 15D. Bullhorn, based in Boston, bought the company for EUR 300 million in June 2024, and the Dutch entity kept its Amsterdam headquarters, its own domain and its own product line. That places it with Silo AI under AMD and Sana Labs under Workday rather than with Exscientia, so the note carries the acquisition.
- **[HrFlow.ai](https://hrflow.ai)** (France, HR data). The operating entity is RIMINDER SAS, RCS Paris 820 725 273, registered office 9 rue des Colonnes, 75002 Paris. The company sells parsing, tagging, embedding and matching APIs for HR data and raised a USD 7 million pre-Series A in April 2026.
- **[Retorio](https://www.retorio.com)** (Germany, Training). Retorio GmbH sits in the Munich commercial register at HRB 243225. The company spun out of the Technical University of Munich in 2018 and runs AI video simulations that coach sales, service and leadership staff.
- **[bettermarks](https://bettermarks.com)** (Germany, Education). bettermarks GmbH is registered at Amtsgericht Charlottenburg HRB 120966 B, Skalitzer Strasse 85-86, 10997 Berlin, VAT DE261509841. Its adaptive maths courseware serves schools in Germany, the Netherlands, Uruguay and Mexico.
- **[CENTURY Tech](https://www.century.tech)** (UK, Education). Century-Tech Limited is active at Companies House 08482934, incorporated on 10 April 2013, registered office The Broadway, London SW19 1RD. The platform builds personalised learning paths and reports class-level analytics to teachers.

## Corrections

- **Oxipit** now records the Sectra acquisition. Sectra AB agreed to buy Oxipit, UAB on 5 March 2026 and closed the deal in April 2026. The Vilnius team became an AI development centre inside Sectra's Imaging IT Solutions division, oxipit.ai still serves the company's own site, and the parent is Swedish, so the entry stays with the acquisition in its note.

## Removals

None this run.

## Needs a human call

Nothing new. Pull request #15 remains open and waits on the contributor: llmtech.eu still names no Polish entity, and the request for a KRS or NIP number from 31 August has had no answer.

## What else the sweep checked

The other 24 entries in today's slice hold. Tekever is raising at a EUR 5.5 billion valuation from Lisbon, DRUID AI still files from Bucharest despite the 2023 talk of moving to Austin, Quibim keeps its Valencia headquarters while opening in New York, Robovision remains in Ghent, constellr raised EUR 37 million in February 2026 and stays German, and Nuritas, Turbine, Whispp, Gideon Brothers, DoMore Diagnostics and IDENER are all trading from where the list says they are.

The link check on main passed on its last two scheduled runs, so no broken URLs to fix. `scripts/check-sync.py` passes on this branch with 83 applied AI entries in both files.