### PR TITLE
Daily sweep 2026-09-03

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,11 @@ Companies applying AI to specific domains.
 | [Didimo](https://www.didimo.co) | 🇵🇹 Portugal | Digital humans | Automated 3D avatars and game characters |
 | [modl.ai](https://modl.ai) | 🇩🇰 Denmark | Gaming | AI bots for automated game testing |
 | [ai-coustics](https://ai-coustics.com) | 🇩🇪 Germany | Audio | Real-time speech enhancement for voice AI |
+| [Aqemia](https://aqemia.com) | 🇫🇷 France | Drug discovery | Physics-based generative AI for small molecules |
+| [Iktos](https://iktos.ai) | 🇫🇷 France | Drug discovery | Generative chemistry and retrosynthesis with robotics |
+| [Cradle](https://www.cradle.bio) | 🇳🇱 Netherlands | Protein design | AI protein engineering software for R&D teams |
+| [Basecamp Research](https://basecamp-research.com) | 🇬🇧 UK | Biodiversity data | BaseData protein knowledge graph for biology models |
+| [LabGenius](https://labgeniustx.com) | 🇬🇧 UK | Antibodies | EVA platform designs multispecific cancer antibodies |
 
 ### AI infrastructure
 
@@ -160,12 +165,12 @@ Companies building infrastructure for AI workloads.
 | [Northern Data](https://northerndata.de) | 🇩🇪 Germany | HPC | High-performance computing, RUM Group subsidiary since 2026 |
 | [VSHN](https://www.vshn.ch) | 🇨🇭 Switzerland | Cloud | Swiss cloud, Kubernetes for AI |
 | [Berget AI](https://berget.ai) | 🇸🇪 Sweden | Cloud | Sovereign AI infrastructure, GDPR-compliant |
-| [Cortecs](https://cortecs.ai) | 🇪🇺 EU | Inference | European AI gateway, LLM routing |
-| [Axelera AI](https://axelera.ai) | 🇳🇱 Netherlands | Hardware | Europa edge inference chips, €211M raised |
+| [Cortecs](https://cortecs.ai) | 🇦🇹 Austria | Inference | European AI gateway, LLM routing |
+| [Axelera AI](https://axelera.ai) | 🇳🇱 Netherlands | Hardware | Europa edge inference chips, over $450M raised |
 | [Innatera](https://www.innatera.com) | 🇳🇱 Netherlands | Hardware | Neuromorphic microcontrollers for the sensor edge |
 | [SEMRON](https://semron.com) | 🇩🇪 Germany | Hardware | 3D memcapacitive chips for on-device inference |
 | [SpiNNcloud](https://spinncloud.com) | 🇩🇪 Germany | Hardware | SpiNNaker2 neuromorphic supercomputers |
-| [Fractile](https://fractile.ai) | 🇬🇧 UK | Hardware | In-memory compute for LLM inference |
+| [Fractile](https://fractile.ai) | 🇬🇧 UK | Hardware | In-memory compute for LLM inference, $220M Series B |
 | [VSORA](https://vsora.com) | 🇫🇷 France | Hardware | Jotunn8 inference processor for data centres |
 | [Qdrant](https://qdrant.tech) | 🇩🇪 Germany | Vector search | Open source vector database in Rust |
 | [Weaviate](https://weaviate.io) | 🇳🇱 Netherlands | Vector search | Vector database with built-in vectorisation |
@@ -178,7 +183,7 @@ Companies building AI-powered developer and productivity tools.
 | Company | Country | Focus | Notes |
 |---------|---------|-------|-------|
 | [LangWatch](https://langwatch.ai) | 🇳🇱 Netherlands | LLM observability | Quality and security monitoring for GenAI |
-| [Jina AI](https://jina.ai) | 🇩🇪 Germany | Embeddings | Multimodal AI, neural search |
+| [Jina AI](https://jina.ai) | 🇩🇪 Germany | Embeddings | Multimodal AI and neural search, Elastic subsidiary since 2025 |
 | [Lovable](https://lovable.dev) | 🇸🇪 Sweden | Code generation | AI app builder, exports real code |
 | [Framer](https://framer.com) | 🇳🇱 Netherlands | Web design | AI-assisted website builder |
 | [DataSnipper](https://datasnipper.com) | 🇳🇱 Netherlands | Audit | AI-driven audit automation, unicorn |

--- a/data/companies.json
+++ b/data/companies.json
@@ -761,6 +761,46 @@
       "country_code": "DE",
       "focus": "Audio",
       "notes": "Real-time speech enhancement for voice AI"
+    },
+    {
+      "name": "Aqemia",
+      "url": "https://aqemia.com",
+      "country": "France",
+      "country_code": "FR",
+      "focus": "Drug discovery",
+      "notes": "Physics-based generative AI for small molecules"
+    },
+    {
+      "name": "Iktos",
+      "url": "https://iktos.ai",
+      "country": "France",
+      "country_code": "FR",
+      "focus": "Drug discovery",
+      "notes": "Generative chemistry and retrosynthesis with robotics"
+    },
+    {
+      "name": "Cradle",
+      "url": "https://www.cradle.bio",
+      "country": "Netherlands",
+      "country_code": "NL",
+      "focus": "Protein design",
+      "notes": "AI protein engineering software for R&D teams"
+    },
+    {
+      "name": "Basecamp Research",
+      "url": "https://basecamp-research.com",
+      "country": "UK",
+      "country_code": "GB",
+      "focus": "Biodiversity data",
+      "notes": "BaseData protein knowledge graph for biology models"
+    },
+    {
+      "name": "LabGenius",
+      "url": "https://labgeniustx.com",
+      "country": "UK",
+      "country_code": "GB",
+      "focus": "Antibodies",
+      "notes": "EVA platform designs multispecific cancer antibodies"
     }
   ],
   "infrastructure": [
@@ -847,8 +887,8 @@
     {
       "name": "Cortecs",
       "url": "https://cortecs.ai",
-      "country": "EU",
-      "country_code": "EU",
+      "country": "Austria",
+      "country_code": "AT",
       "focus": "Inference",
       "notes": "European AI gateway, LLM routing"
     },
@@ -858,7 +898,7 @@
       "country": "Netherlands",
       "country_code": "NL",
       "focus": "Hardware",
-      "notes": "Europa edge inference chips, €211M raised"
+      "notes": "Europa edge inference chips, over $450M raised"
     },
     {
       "name": "Innatera",
@@ -890,7 +930,7 @@
       "country": "UK",
       "country_code": "GB",
       "focus": "Hardware",
-      "notes": "In-memory compute for LLM inference"
+      "notes": "In-memory compute for LLM inference, $220M Series B"
     },
     {
       "name": "VSORA",
@@ -940,7 +980,7 @@
       "country": "Germany",
       "country_code": "DE",
       "focus": "Embeddings",
-      "notes": "Multimodal AI, neural search"
+      "notes": "Multimodal AI and neural search, Elastic subsidiary since 2025"
     },
     {
       "name": "Lovable",


### PR DESCRIPTION
Daily sweep for 2026-09-03. The search angle this run was European AI for drug discovery and life sciences. The list held four entries in that area before this branch: Owkin, Nuritas, Turbine and the pathology entries from the 26 August sweep.

Pull requests #23 and #24, the sweeps for 1 and 2 September, are still open and unmerged. This branch starts from main and repeats none of their proposals.

The audit slice was 25 entries at offset 97, covering the whole AI infrastructure section and the first seven AI tools entries. Four of them changed.

## Additions

- **[Aqemia](https://aqemia.com)** (France, Drug discovery). AQEMIA is a SAS created on 12 June 2019, SIREN 851 519 702, registered office 231 rue Saint-Honoré, 75001 Paris. The company spun out of the École normale supérieure and runs physics-based molecular simulation to generate its own training data rather than learning from experimental sets. Sanofi expanded its multi-year collaboration in January 2026. It opened a London office in 2025 and the entity stays French.
- **[Iktos](https://iktos.ai)** (France, Drug discovery). Iktos registered on 17 October 2016 under SIREN 823 189 279, registered office 65 rue de Prony, 75017 Paris. It combines generative chemistry, retrosynthesis and lab robotics through its Makya platform. Pierre Fabre Laboratories signed an integrated oncology discovery collaboration with the company on 9 January 2026.
- **[Cradle](https://www.cradle.bio)** (Netherlands, Protein design). Cradle Bio B.V. holds KVK 84219092 with its registered office at Radarweg 60 Unit 5.2, 1043 NT Amsterdam, and a second office in Zurich. IVP led a $73 million Series B that took total funding past $100 million. The platform designs antibodies, enzymes and peptides, and Cradle reports six of the top 25 pharma companies as customers.
- **[Basecamp Research](https://basecamp-research.com)** (UK, Biodiversity data). Basecamp Research Ltd sits at Companies House 12354133 and filed its accounts for the year ending 31 December 2024 on 10 February 2026. The company builds BaseData, a knowledge graph of 9.8 billion protein sequences collected on field expeditions, and sells it as training data for biology foundation models. Singular led a $60 million Series B.
- **[LabGenius](https://labgeniustx.com)** (UK, Antibodies). LABGENIUS LIMITED is active at Companies House 08183505, incorporated 17 August 2012, registered office G04 Cocoa Studios, 100 Drummond Road, London SE16 4DG. Its EVA platform pairs machine learning with robotic automation to design multispecific antibodies for solid tumours. LG Chem signed a research, option and licence agreement with the company in June 2026.

## Corrections

- **Cortecs moves from the EU flag to Austria.** Cortecs GmbH is registered at the Vienna Commercial Court under FN 560802i, UID ATU77164426, registered office Althanstraße 4, Floor 6, 1090 Vienna, incorporated 31 July 2021 with EUR 35,000 of capital. The entry carried the EU fallback because no entity was on the record. The imprint at cortecs.ai/imprint names one, so the national flag applies.
- **Axelera AI** now records over $450 million raised. Innovation Industries led a round of more than $250 million in February 2026, with BlackRock and SiteGround Capital joining as new investors. That takes the company past $450 million in equity, grants and venture debt since it incorporated in July 2021, so the €211 million figure in the note is stale. The headquarters stays at the High Tech Campus in Eindhoven.
- **Fractile** now records the $220 million Series B. Accel, Factorial Funds and Founders Fund co-led it. The company committed £100 million to its UK sites in February 2026 and is growing London and Bristol, so the entry stays British.
- **Jina AI** now records the Elastic acquisition. Elastic bought the company on 9 October 2025 and Han Xiao became its VP of AI. Jina AI GmbH remains a Berlin entity, jina.ai still serves the company's own site including its legal page, and the parent is Elastic N.V., incorporated in the Netherlands. That places it with Silo AI under AMD rather than with Exscientia, so the entry stays with the acquisition in its note.

## Removals

None this run.

## The link check on this branch is red, and the failure is not this branch's

The `check-links` job failed twice on 7bf72df. The two runs disagree about which URLs are broken, which is what identifies the cause.

Run [100544478405](https://github.com/jmbarrancoml/awesome-european-ai/actions/runs/33722530864/job/100544478405) timed out on one URL, `basecamp-research.com`, which this branch adds. I re-ran the job once. Run [100545162317](https://github.com/jmbarrancoml/awesome-european-ai/actions/runs/33722530864/job/100545162317) passed `basecamp-research.com` and timed out on four different URLs instead: `eurollm.io`, `quibim.com`, `tilde.ai` and `tilde.ai/tildeopen-llm/`. All four are entries that live on main and this diff does not touch.

Both runs report 0 errors. Every failure is a timeout, and the set rotates between runs. The same alternation shows on main: the scheduled run 162 passed on da3c3bc and the push run 161 failed on that same commit. Lychee already runs with a 60 second timeout, four retries and concurrency 4 after the tuning in the 31 August sweep.

I have spent the one re-run, so I am standing down rather than acting further, for these reasons:

- Adding any of these hosts to `.lycheeignore` would be suppressing the check rather than fixing it. Every existing entry in that file records a manual verification, and this sandbox has no outbound network, so I cannot verify one.
- Tuning the lychee flags again would be a third speculative guess at a problem two earlier rounds did not fix, and it would widen a sweep PR into a CI change.
- None of the five URLs this branch adds is unreachable. `basecamp-research.com` passed on the second run.

What would settle it is one manual check of the four hosts from a normal connection. If they answer, the checker needs a longer timeout or lower concurrency, and that belongs in its own commit rather than this one.

## Needs a human call

- **Pull request #15 still waits on the two things I named on 2 September**, and neither has moved. The CEIDG lookup by NIP 7792605454 at aplikacja.ceidg.gov.pl needs a browser, and my sandbox has no outbound network. The link check on that branch still sits at `action_required` and has never run against e320408. Pessimist228 has posted nothing since 1 September, so I left no further comment rather than repeating the standing verdict.
- **One detail in that thread changed today.** Pessimist228 cited Cortecs as the precedent for keeping the EU flag in the AI infrastructure section. This branch moves Cortecs to Austria on its Vienna register entry, so that precedent no longer stands. The reasoning for LLM Tech is unaffected, since the CEIDG record decides it either way.
- **My earlier comment on #15 carries a "Generated by Claude Code" footer.** It is the last one in the thread, posted on 2 September. Removing it takes an edit through the GitHub web UI. The same footer was appended to this pull request body when I opened it and I stripped it, which is also why the link check finding above sits here rather than in a comment: comments cannot be edited back out through the tools I have.

## What else the sweep checked

The other 21 entries in the slice hold. VSORA closed further funding led by Ardian in July 2026 and is taking Jotunn8 into manufacturing from France. SEMRON is still in Dresden and expects first silicon this year. Nebius keeps its Amsterdam headquarters and opened a new office there. Verda is trading from Helsinki after the DataCrunch rename, which the note already records, and Northern Data already carries the RUM Group acquisition from the 20 August sweep. Berget AI is in Stockholm, Regolo runs on Seeweb infrastructure from Frosinone, Valohai is independent in Turku and LangWatch is in Amsterdam. Superwise keeps its two flags, which the criteria say to leave alone.

`python3 scripts/check-sync.py` passes on this branch with 83 applied AI entries in both files.