### PR TITLE
Daily sweep 2026-09-04

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,10 @@ Companies building infrastructure for AI workloads.
 | [Qdrant](https://qdrant.tech) | 🇩🇪 Germany | Vector search | Open source vector database in Rust |
 | [Weaviate](https://weaviate.io) | 🇳🇱 Netherlands | Vector search | Vector database with built-in vectorisation |
 | [Verda](https://verda.com) | 🇫🇮 Finland | Cloud | GPU cloud with own datacentres, formerly DataCrunch |
+| [Flower Labs](https://flower.ai) | 🇩🇪 Germany | Federated learning | Maintains the Flower federated learning framework |
+| [Apheris](https://www.apheris.com) | 🇩🇪 Germany | Federated computing | Federated learning for life sciences data networks |
+| [Decentriq](https://www.decentriq.com) | 🇨🇭 Switzerland | Data clean rooms | Confidential computing for regulated data collaboration |
+| [Tune Insight](https://tuneinsight.com) | 🇨🇭 Switzerland | Encrypted analytics | Hospital data collaboration, EPFL spin-off |
 
 ### AI tools
 
@@ -187,12 +191,12 @@ Companies building AI-powered developer and productivity tools.
 | [Deepset](https://deepset.ai) | 🇩🇪 Germany | NLP | Enterprise NLP, creators of Haystack |
 | [Rasa](https://rasa.com) | 🇩🇪 Germany | Chatbots | Open source conversational AI |
 | [LightOn](https://lighton.ai) | 🇫🇷 France | Enterprise LLMs | First European GenAI IPO (2024) |
-| [Dust](https://dust.tt) | 🇫🇷 France | LLM connectors | Connect LLMs to internal data (Notion, Slack) |
-| [Parloa](https://parloa.com) | 🇩🇪 Germany | Contact centers | Conversational AI platform, unicorn |
+| [Dust](https://dust.tt) | 🇫🇷 France | AI agents | Shared agent workspace over internal company data |
+| [Parloa](https://parloa.com) | 🇩🇪 Germany | Contact centers | Conversational AI platform, $3B valuation |
 | [Noota](https://noota.io) | 🇫🇷 France | Meetings | AI meeting transcription and summaries |
 | [Codesphere](https://codesphere.com) | 🇩🇪 Germany | Cloud IDE | Code and deploy in the cloud |
 | [ElevenLabs](https://elevenlabs.io) | 🇵🇱/🇬🇧 Poland/UK | Voice AI | Text-to-speech, voice cloning |
-| [Onfido](https://onfido.com) | 🇬🇧 UK | Identity | AI identity verification |
+| [Onfido](https://onfido.com) | 🇬🇧 UK | Identity | AI identity verification, sold as Entrust IDV since 2024 |
 | [Mindee](https://mindee.com) | 🇫🇷 France | Documents | AI document parsing API |
 | [Rossum](https://rossum.ai) | 🇨🇿 Czechia | Documents | AI document processing, acquired by Coupa |
 | [n8n](https://n8n.io) | 🇩🇪 Germany | Automation | Fair-code workflow and agent builder |

--- a/data/companies.json
+++ b/data/companies.json
@@ -923,6 +923,38 @@
       "country_code": "FI",
       "focus": "Cloud",
       "notes": "GPU cloud with own datacentres, formerly DataCrunch"
+    },
+    {
+      "name": "Flower Labs",
+      "url": "https://flower.ai",
+      "country": "Germany",
+      "country_code": "DE",
+      "focus": "Federated learning",
+      "notes": "Maintains the Flower federated learning framework"
+    },
+    {
+      "name": "Apheris",
+      "url": "https://www.apheris.com",
+      "country": "Germany",
+      "country_code": "DE",
+      "focus": "Federated computing",
+      "notes": "Federated learning for life sciences data networks"
+    },
+    {
+      "name": "Decentriq",
+      "url": "https://www.decentriq.com",
+      "country": "Switzerland",
+      "country_code": "CH",
+      "focus": "Data clean rooms",
+      "notes": "Confidential computing for regulated data collaboration"
+    },
+    {
+      "name": "Tune Insight",
+      "url": "https://tuneinsight.com",
+      "country": "Switzerland",
+      "country_code": "CH",
+      "focus": "Encrypted analytics",
+      "notes": "Hospital data collaboration, EPFL spin-off"
     }
   ],
   "tools": [
@@ -1011,8 +1043,8 @@
       "url": "https://dust.tt",
       "country": "France",
       "country_code": "FR",
-      "focus": "LLM connectors",
-      "notes": "Connect LLMs to internal data (Notion, Slack)"
+      "focus": "AI agents",
+      "notes": "Shared agent workspace over internal company data"
     },
     {
       "name": "Parloa",
@@ -1020,7 +1052,7 @@
       "country": "Germany",
       "country_code": "DE",
       "focus": "Contact centers",
-      "notes": "Conversational AI platform, unicorn"
+      "notes": "Conversational AI platform, $3B valuation"
     },
     {
       "name": "Noota",
@@ -1052,7 +1084,7 @@
       "country": "UK",
       "country_code": "GB",
       "focus": "Identity",
-      "notes": "AI identity verification"
+      "notes": "AI identity verification, sold as Entrust IDV since 2024"
     },
     {
       "name": "Mindee",


### PR DESCRIPTION
Daily sweep for 2026-09-04. The search angle this run was European privacy-preserving and federated AI, a segment the list did not cover. Sherpa.ai mentions federated learning in its note and the Flower framework sits in the open source section, but no company in the list sells federated or encrypted computation as its product.

Pull requests #23, #24 and #25, the sweeps for 1, 2 and 3 September, are still open and unmerged. This branch starts from main and repeats none of their proposals.

The audit slice was 25 entries at offset 122, covering the second half of AI tools and the first ten research labs. Four of them changed.

## Additions

- **[Flower Labs](https://flower.ai)** (Germany, Federated learning). Flower Labs GmbH is registered at Amtsgericht Hamburg HRB 160919, VAT DE327829299, address Winterhuder Weg 29, 22085 Hamburg, with Daniel J. Beutel and Taner Topal as managing directors. The company maintains Flower, which the open source section already lists, and closed a $20 million Series A led by Felicis. Nokia, Porsche and Brave run it in production.
- **[Apheris](https://www.apheris.com)** (Germany, Federated computing). apheris AI GmbH sits in the Berlin commercial register at Amtsgericht Charlottenburg HRB 221842 B, address Lohmühlenstraße 65, 12435 Berlin. Its Compute Gateway runs machine learning across pharmaceutical data that stays with its owner. AbbVie, AstraZeneca and Bristol Myers Squibb use it, and eCAPITAL and OTB Ventures led the Series A that took total funding past $20 million.
- **[Decentriq](https://www.decentriq.com)** (Switzerland, Data clean rooms). Decentriq AG holds UID CHE-485.437.962 in the Zurich commercial register and entered it on 30 August 2019. The platform builds data clean rooms on confidential computing hardware, so neither the other participants, nor Decentriq, nor the cloud provider can read the raw data. Eclipse Ventures led a $15 million Series A with Paladin Capital Group and btov Partners.
- **[Tune Insight](https://tuneinsight.com)** (Switzerland, Encrypted analytics). Tune Insight SA holds UID CHE-357.768.761, registered office EPFL Innovation Park Building C, 1015 Lausanne, founded 2021 with Juan Troncoso Pastoriza as president. The company spun out of EPFL and runs multiparty homomorphic encryption so hospitals can compute together without moving records. University Hospital Zurich, CHUV and Inselspital run it.

## Corrections

- **Onfido** now records the Entrust acquisition. Entrust Corporation completed the $650 million purchase on 9 April 2024 and has since retired the brand: entrust.com carries a page headed "Onfido Is Now Entrust IDV", the two companies merged their social accounts on 1 April 2025, and the documentation portal moved from documentation.onfido.com to documentation.identity.entrust.com. The product sells as Entrust IDV on every reseller listing. See the human call below on whether the entry should stay at all.
- **Parloa** now records the $3 billion valuation. General Catalyst led a $350 million Series D announced on 15 January 2026, with EQT Ventures, Altimeter Capital, Durable Capital and Mosaic Ventures returning. That is three times the $1 billion of eight months earlier, so "unicorn" understates the entry. The company keeps its Berlin headquarters and is hiring toward 600 staff.
- **Dust** now describes what the product became. Sequoia and Abstract co-led a $40 million Series B on 18 May 2026, with Datadog and Snowflake joining, and total funding passed $60 million. Dust sells a shared workspace where teams build and run AI agents on company data. The old note named the Notion and Slack connectors, which are one feature of that.

## Removals

None this run.

## Needs a human call

- **Onfido may no longer qualify, and the two tests disagree.** ONFIDO LTD (Companies House 07479524) and ONFIDO HOLDINGS LIMITED (13693711) are both active, which is the Silo AI case and argues for keeping the entry. Against that, Entrust has retired the brand, and a search index returns onfido.com under the title "Identity Verification (IDV) Solutions | Entrust", which points at the Exscientia case. My sandbox has no outbound network, so I cannot open onfido.com and see whether it serves Onfido's own site or Entrust's. One look settles it. I corrected the note and left the entry in place.
- **Rasa is listed as German and its group headquarters may be American.** rasa.com/imprint names Rasa Technologies GmbH, Schönhauser Allee 175, 10119 Berlin, Amtsgericht Charlottenburg HRB 184024 B, VAT DE311844583, with Alan Nichol as managing director. Rasa Technologies, Inc. was incorporated in Delaware on 19 November 2019 and CB Insights, PitchBook and ZoomInfo all place the headquarters at 4 Embarcadero Center, San Francisco. If the Inc. is the parent and the GmbH is its subsidiary, this is the Hugging Face case rather than the Silo AI one. The imprint is the only primary source I found and it names the German entity, so I left the entry alone.
- **Pull request #15 still waits on the CEIDG lookup.** Nothing has moved since 2 September. The check is a search by NIP 7792605454 at aplikacja.ceidg.gov.pl, which needs a browser my sandbox does not have. Pessimist228 has posted nothing since 1 September, so I left no further comment.

## What else the sweep checked

The other 21 entries in the slice hold. Rossum was acquired by Coupa on 12 May 2026 and Langfuse by ClickHouse on 16 January 2026, and both notes already record it. Mindee is MINDEE SAS, RCS Paris 837 811 256, registered office 14 rue Charles V, 75004 Paris, so the aggregators that place it in San Francisco are wrong about the entity. Codesphere is now Codesphere SE with its headquarters at Zur Gießerei 6 in Karlsruhe-Durlach and offices in Munich and New York. LatticeFlow AI bought AI Sonar of Dublin on 21 January 2026, so it is the acquirer. n8n doubled to a $5.2 billion valuation after SAP invested in May 2026, which the note does not claim either way. LightOn, Deepset, Noota and Giskard are trading from where the list says they are, and the ten research labs in the slice are unchanged, CAIRNE included.

The link check on main passed on its last two runs, 164 and 165, so there are no broken URLs to fix and no link issue is open. `python3 scripts/check-sync.py` passes on this branch with 24 AI infrastructure entries in both files.

One company outside the list is worth recording. MOSTLY AI Solutions MP GmbH of Vienna, Firmenbuch FN 466390v, entered liquidation on 14 March 2026 with Tobias Hann and Michael Platzer as liquidators. It is not in the list, so there is nothing to remove, and mostly.ai now presents itself as powered by Syntho.