### PR TITLE
Daily sweep 2026-09-05

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,11 @@ Companies applying AI to specific domains.
 | [Didimo](https://www.didimo.co) | 🇵🇹 Portugal | Digital humans | Automated 3D avatars and game characters |
 | [modl.ai](https://modl.ai) | 🇩🇰 Denmark | Gaming | AI bots for automated game testing |
 | [ai-coustics](https://ai-coustics.com) | 🇩🇪 Germany | Audio | Real-time speech enhancement for voice AI |
+| [MVTec](https://www.mvtec.com) | 🇩🇪 Germany | Machine vision | HALCON and MERLIC libraries for industrial inspection |
+| [Scortex](https://scortex.io) | 🇫🇷 France | Manufacturing | Deep learning visual quality control, TRIGO group |
+| [KONUX](https://konux.com) | 🇩🇪 Germany | Rail | Predictive maintenance for railway switches and track |
+| [Braincube](https://braincube.com) | 🇫🇷 France | Manufacturing | Industrial IIoT platform with process optimisation AI |
+| [Covision Lab](https://www.covisionlab.com) | 🇮🇹 Italy | Computer vision | Vision AI lab, Covision Quality inspection software |
 
 ### AI infrastructure
 

--- a/data/companies.json
+++ b/data/companies.json
@@ -761,6 +761,46 @@
       "country_code": "DE",
       "focus": "Audio",
       "notes": "Real-time speech enhancement for voice AI"
+    },
+    {
+      "name": "MVTec",
+      "url": "https://www.mvtec.com",
+      "country": "Germany",
+      "country_code": "DE",
+      "focus": "Machine vision",
+      "notes": "HALCON and MERLIC libraries for industrial inspection"
+    },
+    {
+      "name": "Scortex",
+      "url": "https://scortex.io",
+      "country": "France",
+      "country_code": "FR",
+      "focus": "Manufacturing",
+      "notes": "Deep learning visual quality control, TRIGO group"
+    },
+    {
+      "name": "KONUX",
+      "url": "https://konux.com",
+      "country": "Germany",
+      "country_code": "DE",
+      "focus": "Rail",
+      "notes": "Predictive maintenance for railway switches and track"
+    },
+    {
+      "name": "Braincube",
+      "url": "https://braincube.com",
+      "country": "France",
+      "country_code": "FR",
+      "focus": "Manufacturing",
+      "notes": "Industrial IIoT platform with process optimisation AI"
+    },
+    {
+      "name": "Covision Lab",
+      "url": "https://www.covisionlab.com",
+      "country": "Italy",
+      "country_code": "IT",
+      "focus": "Computer vision",
+      "notes": "Vision AI lab, Covision Quality inspection software"
     }
   ],
   "infrastructure": [


### PR DESCRIPTION
Angle this run: European AI for manufacturing and industrial inspection. The list already covers mobile robots and humanoids from the 27 August sweep, but machine vision software and industrial process AI were absent.

## Additions

- **[MVTec](https://www.mvtec.com)**, Germany. Machine vision software vendor behind HALCON and MERLIC. Its imprint gives Arnulfstr. 205, 80634 Munich, Amtsgericht München HRB 114695, managing director Olaf Munkelt. MVTec was founded in 1996 and remains independent. It shipped a new HALCON release on 20 May 2026 and announced a ZEISS integration the same month.
- **[Scortex](https://scortex.io)**, France. Deep learning for automated visual quality control on production lines, based at 22 rue Berbier du Mets in Paris. TRIGO Group, the French quality engineering firm owned by Ardian, acquired Scortex in 2022 and put €5M into it. Scortex kept its name, its Paris office and a team of about 30, and published product updates through May 2026. Both the entity and the parent are French.
- **[KONUX](https://konux.com)**, Germany. Sensors and machine learning that predict failures in railway switches and track, at Flossergasse 2 in Munich. Four TUM students founded it in 2014 and it has raised $135M. KONUX signed a partnership with Rail Power Systems GmbH in September 2025.
- **[Braincube](https://braincube.com)**, France. Industrial IIoT platform with process optimisation AI, used by Michelin, Saint-Gobain and Heineken. Three French engineers founded it in Issoire in 2007. It employs about 250 people and raised more than €80M in November 2023 in a round led by Scottish Equity Partners and Bpifrance. The headquarters stay in Issoire, with offices in Paris, Boston and São Paulo.
- **[Covision Lab](https://www.covisionlab.com)**, Italy. Computer vision and AI centre in Bressanone, South Tyrol, founded in 2019 by seven industrial companies. Its Covision Quality product automates visual inspection of metal and plastic parts for GKN and Toyota Motor Europe. The register lists Covision Lab SCARL, Via Julius Durst 4, 39042 Bressanone, VAT 03045030214.

## Corrections

None. Today's slice covered the research labs and the open source projects. Earlier sweeps had already recorded everything that moved: Argilla reads "part of Hugging Face", OpenNMT reads "succeeded by Eole", Rasa Open Source reads "now in maintenance mode". I checked each against current sources and all three hold. Rasa Technologies GmbH is registered in Berlin at HRB 184024 B and trading. PySyft took commits in August 2026 and runs the US Census Bureau and Reddit researcher programmes, so the entry is accurate.

## Removals

None.

## Needs a human call

- **Argilla, once the NVIDIA deal closes.** NVIDIA agreed on 3 September 2026 to buy Hugging Face for $12.93 billion, which NVIDIA reported in an 8-K. The transaction is expected to close in the first half of 2027 subject to regulatory approval, so nothing has changed today. Argilla sits in the open source section on the strength of its Spanish maintainers, who have kept the repository active into August 2026. This list removed Hugging Face itself for being a Delaware company headquartered in New York. The question when the deal closes is whether Spanish maintainership carries the entry, as it does for Silo AI under AMD, or whether the project reads as an NVIDIA one by then. I left the entry untouched.

## Checked and rejected

Recording these so a later sweep does not re-propose them.

- **Micropsi Industries** reparented to the United States in September 2024. Micropsi Industries, Inc. of San Francisco is the parent and the Berlin GmbH is now a subsidiary, so it fails the headquarters test the same way Cognite does.
- **Alteia** of Toulouse was acquired by GE Vernova in July 2025 and its product now ships as GridOS Visual Intelligence. That is the Exscientia pattern.
- **Deepomatic** of Paris was acquired by IQGeo in March 2025. I could not establish whether the brand survives, so I am proposing nothing either way.

The link check on this branch will validate the five new URLs.